### PR TITLE
datalayerstore fix

### DIFF
--- a/hosteddatalayer/src/main/java/com/tealium/hosteddatalayer/DataLayerStore.kt
+++ b/hosteddatalayer/src/main/java/com/tealium/hosteddatalayer/DataLayerStore.kt
@@ -137,7 +137,7 @@ class DataLayerStore(config: TealiumConfig,
 
     private fun filesSortedByAge(): Array<File> {
         return hdlDirectory.listFiles()?.also { file ->
-            file.sortByDescending { it.lastModified() }
+            file.sortBy { it.lastModified() }
         } ?: emptyArray()
     }
 

--- a/hosteddatalayer/src/test/java/com/tealium/hosteddatalayer/DataLayerStoreTests.kt
+++ b/hosteddatalayer/src/test/java/com/tealium/hosteddatalayer/DataLayerStoreTests.kt
@@ -285,7 +285,7 @@ class DataLayerStoreTests {
 
         repeat (defaultCacheSize + 5) {
             val entry = HostedDataLayerEntry("entry$it",
-                    System.currentTimeMillis() - it * 10,
+                    System.currentTimeMillis() - ((defaultCacheSize + 5) * 100) + it * 10,
                         JSONObject("{}")
                     )
             store.insert(entry)


### PR DESCRIPTION
 - fix for failing test `size_doesNotExceedMax_AndRemovesOldest` - was working on my device
 - sort order was incorrect, and timestamp generation was the wrong way round.