### PR TITLE
rc test fixes

### DIFF
--- a/hosteddatalayer/build.gradle
+++ b/hosteddatalayer/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'maven-publish'
 
 version = '0.1.0'
 

--- a/remotecommanddispatcher/src/androidTest/java/com/tealium/remotecommanddispatcher/RemoteCommandDispatcherTests.kt
+++ b/remotecommanddispatcher/src/androidTest/java/com/tealium/remotecommanddispatcher/RemoteCommandDispatcherTests.kt
@@ -7,7 +7,7 @@ import com.tealium.core.JsonUtils
 import com.tealium.core.TealiumConfig
 import com.tealium.core.TealiumContext
 import com.tealium.core.network.NetworkClient
-import com.tealium.dispatcher.EventDispatch
+import com.tealium.dispatcher.TealiumEvent
 import com.tealium.remotecommanddispatcher.remotecommands.HttpRemoteCommand
 import com.tealium.remotecommanddispatcher.remotecommands.JsonRemoteCommand
 import com.tealium.remotecommanddispatcher.remotecommands.RemoteCommand
@@ -56,7 +56,7 @@ class RemoteCommandDispatcherTests {
         every { mockRemoteCommandConfig.apiCommands?.get("event_test") } returns "test_command"
 
         remoteCommandDispatcher.add(jsonCommand)
-        val dispatch = EventDispatch("event_test", mapOf("key1" to "value1", "key2" to "value2"))
+        val dispatch = TealiumEvent("event_test", mapOf("key1" to "value1", "key2" to "value2"))
         remoteCommandDispatcher.onProcessRemoteCommand(dispatch)
 
         verify { jsonCommand.invoke(any()) }


### PR DESCRIPTION
 - DispatchRouter test fixes
 - change `EventDispatch` to `TealiumEvent` in `RemoteCommandDispatcherTests`
 - maven-publish addition missed off the hdl commit