### PR TITLE
migrator updates

### DIFF
--- a/lifecycle/src/androidTest/java/com/tealium/lifecycle/MigrationTests.kt
+++ b/lifecycle/src/androidTest/java/com/tealium/lifecycle/MigrationTests.kt
@@ -1,0 +1,134 @@
+package com.tealium.lifecycle
+
+import android.app.Application
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import com.tealium.core.Environment
+import com.tealium.core.Tealium
+import com.tealium.core.TealiumConfig
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_LAUNCH
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_SLEEP
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_TOTAL_CRASH
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_TOTAL_LAUNCH
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_TOTAL_SLEEP
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_TOTAL_WAKE
+import com.tealium.lifecycle.LifecycleSPKey.COUNT_WAKE
+import com.tealium.lifecycle.LifecycleSPKey.LAST_EVENT
+import com.tealium.lifecycle.LifecycleSPKey.PRIOR_SECONDS_AWAKE
+import com.tealium.lifecycle.LifecycleSPKey.TIMESTAMP_FIRST_LAUNCH
+import com.tealium.lifecycle.LifecycleSPKey.TIMESTAMP_LAST_LAUNCH
+import com.tealium.lifecycle.LifecycleSPKey.TIMESTAMP_LAST_SLEEP
+import com.tealium.lifecycle.LifecycleSPKey.TIMESTAMP_LAST_WAKE
+import com.tealium.lifecycle.LifecycleSPKey.TIMESTAMP_UPDATE
+import com.tealium.lifecycle.LifecycleSPKey.TOTAL_SECONDS_AWAKE
+import io.mockk.MockKAnnotations
+import junit.framework.Assert.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class MigrationTests {
+
+    // file names from legacy java library
+    val lifecyclePreferencesNamePrefix = "tealium.lifecycle"
+    lateinit var legacyPreferences: SharedPreferences
+
+    lateinit var application: Application
+    lateinit var config: TealiumConfig
+    lateinit var tealium: Tealium
+
+    private lateinit var lifecycleSharedPreferences: LifecycleSharedPreferences
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        application = ApplicationProvider.getApplicationContext()
+        config = TealiumConfig(application, "test", "test", Environment.DEV)
+        legacyPreferences = application.getSharedPreferences("$lifecyclePreferencesNamePrefix.${getHashCodeString(config)}", 0)
+
+        lifecycleSharedPreferences = LifecycleSharedPreferences(config)
+    }
+
+    @After
+    fun tearDown() {
+        legacyPreferences.edit().clear()
+    }
+
+    @Test
+    fun constants_lifecycle_areSameAsLegacyJavaLibrary() {
+        // lifecycle constants from legacy library
+        assertEquals("timestamp_update", TIMESTAMP_UPDATE)
+        assertEquals("timestamp_first_launch", TIMESTAMP_FIRST_LAUNCH)
+        assertEquals("timestamp_last_launch", TIMESTAMP_LAST_LAUNCH)
+        assertEquals("timestamp_last_wake", TIMESTAMP_LAST_WAKE)
+        assertEquals("timestamp_last_sleep", TIMESTAMP_LAST_SLEEP)
+        assertEquals("count_launch", COUNT_LAUNCH)
+        assertEquals("count_sleep", COUNT_SLEEP)
+        assertEquals("count_wake", COUNT_WAKE)
+        assertEquals("count_total_crash", COUNT_TOTAL_CRASH)
+        assertEquals("count_total_launch", COUNT_TOTAL_LAUNCH)
+        assertEquals("count_total_sleep", COUNT_TOTAL_SLEEP)
+        assertEquals("count_total_wake", COUNT_TOTAL_WAKE)
+        assertEquals("last_event", LAST_EVENT)
+        assertEquals("total_seconds_awake", TOTAL_SECONDS_AWAKE)
+        assertEquals("prior_seconds_awake", PRIOR_SECONDS_AWAKE)
+    }
+
+    @Test
+    fun lifecycle_status_timestampsAreMigrated() {
+        val now = System.currentTimeMillis()
+        with(legacyPreferences.edit()) {
+            putLong("timestamp_update", now)
+            putLong("timestamp_first_launch", now)
+            putLong("timestamp_last_launch", now)
+            putLong("timestamp_last_wake", now)
+            putLong("timestamp_last_sleep", now)
+            putLong("last_event", now)
+        }.commit()
+
+        assertEquals(now, lifecycleSharedPreferences.timestampUpdate)
+        assertEquals(now, lifecycleSharedPreferences.timestampFirstLaunch)
+        assertEquals(now, lifecycleSharedPreferences.timestampLastLaunch)
+        assertEquals(now, lifecycleSharedPreferences.timestampLastWake)
+        assertEquals(now, lifecycleSharedPreferences.timestampLastSleep)
+
+        assertEquals(now, lifecycleSharedPreferences.getLastEvent("timestamp_last_launch", -1))
+        assertEquals(now, lifecycleSharedPreferences.getLastEvent("timestamp_last_sleep", -1))
+        assertEquals(now, lifecycleSharedPreferences.getLastEvent("timestamp_last_wake", -1))
+    }
+
+
+    @Test
+    fun lifecycle_status_eventCountsAreMigrated() {
+        val count = 15
+        with(legacyPreferences.edit()) {
+            putInt("count_launch", count)
+            putInt("count_sleep", count)
+            putInt("count_wake", count)
+            putInt("count_total_crash", count)
+            putInt("count_total_launch", count)
+            putInt("count_total_sleep", count)
+            putInt("count_total_wake", count)
+            putInt("total_seconds_awake", count)
+            putInt("prior_seconds_awake", count)
+        }.commit()
+
+        assertEquals(count, lifecycleSharedPreferences.countLaunch)
+        assertEquals(count, lifecycleSharedPreferences.countSleep)
+        assertEquals(count, lifecycleSharedPreferences.countWake)
+        assertEquals(count, lifecycleSharedPreferences.countTotalCrash)
+        assertEquals(count, lifecycleSharedPreferences.countTotalLaunch)
+        assertEquals(count, lifecycleSharedPreferences.countTotalWake)
+        assertEquals(count, lifecycleSharedPreferences.countTotalSleep)
+        assertEquals(count, lifecycleSharedPreferences.totalSecondsAwake)
+        assertEquals(count.toString(), lifecycleSharedPreferences.priorSecondsAwake)
+    }
+
+    fun getHashCodeString(config: TealiumConfig, delimiter: String = ""): String {
+        return Integer.toHexString(
+                (config.accountName + delimiter +
+                        config.profileName + delimiter +
+                        config.environment.environment).hashCode())
+    }
+}

--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/MigrationTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/MigrationTests.kt
@@ -1,0 +1,154 @@
+package com.tealium.core
+
+import android.app.Application
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import com.tealium.core.consent.ConsentCategory
+import com.tealium.core.consent.ConsentManagerConstants.KEY_CATEGORIES
+import com.tealium.core.consent.ConsentManagerConstants.KEY_STATUS
+import com.tealium.core.consent.ConsentStatus
+import io.mockk.MockKAnnotations
+import junit.framework.Assert.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.*
+
+class MigrationTests {
+
+    // file names from legacy java library
+    val consentPreferencesNamePrefix = "tealium.userconsentpreferences"
+    val persistentDataSourcesPreferencesNamePrefix = "tealium.datasources"
+    lateinit var consentPreferences: SharedPreferences
+    lateinit var dataSourcesPreferences: SharedPreferences
+
+    lateinit var application: Application
+    lateinit var config: TealiumConfig
+    lateinit var tealium: Tealium
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        application = ApplicationProvider.getApplicationContext()
+        config = TealiumConfig(application, "test", "test", Environment.DEV)
+        consentPreferences = application.getSharedPreferences("$consentPreferencesNamePrefix.${getHashCodeString(config)}", 0)
+        dataSourcesPreferences = application.getSharedPreferences("$persistentDataSourcesPreferencesNamePrefix.${getHashCodeString(config, ".")}", 0)
+    }
+
+    @After
+    fun tearDown() {
+        consentPreferences.edit().clear()
+        dataSourcesPreferences.edit().clear()
+    }
+
+    @Test
+    fun constants_consent_areSameAsLegacyJavaLibrary() {
+        // consent manager
+        assertEquals("status", KEY_STATUS)
+        assertEquals("categories", KEY_CATEGORIES)
+        // consent status
+        assertEquals("unknown", ConsentStatus.UNKNOWN.value)
+        assertEquals("consented", ConsentStatus.CONSENTED.value)
+        assertEquals("notConsented", ConsentStatus.NOT_CONSENTED.value)
+        // consent categories
+        assertEquals("affiliates", ConsentCategory.AFFILIATES.value)
+        assertEquals("analytics", ConsentCategory.ANALYTICS.value)
+        assertEquals("big_data", ConsentCategory.BIG_DATA.value)
+        assertEquals("cdp", ConsentCategory.CDP.value)
+        assertEquals("cookiematch", ConsentCategory.COOKIEMATCH.value)
+        assertEquals("crm", ConsentCategory.CRM.value)
+        assertEquals("display_ads", ConsentCategory.DISPLAY_ADS.value)
+        assertEquals("email", ConsentCategory.EMAIL.value)
+        assertEquals("engagement", ConsentCategory.ENGAGEMENT.value)
+        assertEquals("mobile", ConsentCategory.MOBILE.value)
+        assertEquals("monitoring", ConsentCategory.MONITORING.value)
+        assertEquals("personalization", ConsentCategory.PERSONALIZATION.value)
+        assertEquals("search", ConsentCategory.SEARCH.value)
+        assertEquals("social", ConsentCategory.SOCIAL.value)
+        assertEquals("misc", ConsentCategory.MISC.value)
+    }
+
+    @Test
+    fun consent_status_consentedStatusIsMigrated() {
+        consentPreferences.edit().putString("status", "consented").commit()
+
+        tealium = Tealium("instance_name", config)
+        assertEquals(ConsentStatus.CONSENTED, tealium.consentManager.userConsentStatus)
+    }
+
+    @Test
+    fun consent_status_notConsentedStatusIsMigrated() {
+        consentPreferences.edit().putString("status", "notConsented").commit()
+
+        tealium = Tealium("instance_name", config)
+        assertEquals(ConsentStatus.NOT_CONSENTED, tealium.consentManager.userConsentStatus)
+    }
+
+    @Test
+    fun consent_status_unknownStatusIsMigrated() {
+        consentPreferences.edit().putString("status", "unknown").commit()
+
+        tealium = Tealium("instance_name", config)
+        assertEquals(ConsentStatus.UNKNOWN, tealium.consentManager.userConsentStatus)
+    }
+
+    @Test
+    fun consent_categories_categoryListIsMigrated() {
+        consentPreferences.edit().putStringSet("categories", setOf("affiliates", "email", "cdp")).commit()
+
+        tealium = Tealium("instance_name", config)
+        val categories = tealium.consentManager.userConsentCategories!!
+        assertNotNull(categories)
+        assertEquals(3, categories.size)
+        assertTrue(categories.contains(ConsentCategory.AFFILIATES))
+        assertTrue(categories.contains(ConsentCategory.EMAIL))
+        assertTrue(categories.contains(ConsentCategory.CDP))
+    }
+
+    @Test
+    fun consent_categories_nullCategoryListIsMigrated() {
+        consentPreferences.edit().putStringSet("categories", null).commit()
+
+        tealium = Tealium("instance_name", config)
+        val categories = tealium.consentManager.userConsentCategories
+        assertNull(categories)
+    }
+
+    @Test
+    fun dataSources_dataGetsMigrated() {
+        with(dataSourcesPreferences.edit()) {
+            putString("my_string", "string_value")
+            putInt("my_int", 100)
+            putFloat("my_float", 100.10F)
+            putLong("my_long", 100L)
+            putBoolean("my_boolean_true", true)
+            putBoolean("my_boolean_false", false)
+            putStringSet("my_string_set", setOf("string_value_1", "string_value_2"))
+        }.commit()
+
+        tealium = Tealium("instance_name", config)
+        assertTrue(tealium.dataLayer.contains("my_string"))
+        assertTrue(tealium.dataLayer.contains("my_int"))
+        assertTrue(tealium.dataLayer.contains("my_float"))
+        assertTrue(tealium.dataLayer.contains("my_long"))
+        assertTrue(tealium.dataLayer.contains("my_boolean_true"))
+        assertTrue(tealium.dataLayer.contains("my_boolean_false"))
+        assertTrue(tealium.dataLayer.contains("my_string_set"))
+
+        assertEquals("string_value", tealium.dataLayer.getString("my_string"))
+        assertEquals(100, tealium.dataLayer.getInt("my_int"))
+        assertEquals(100.10F.toDouble(), tealium.dataLayer.getDouble("my_float"))
+        assertEquals(100L, tealium.dataLayer.getLong("my_long"))
+        assertTrue(tealium.dataLayer.getBoolean("my_boolean_true")!!)
+        assertFalse(tealium.dataLayer.getBoolean("my_boolean_false")!!)
+        assertTrue(Arrays.equals(arrayOf("string_value_1", "string_value_2"), tealium.dataLayer.getStringArray("my_string_set")!!.sortedArray()))
+    }
+
+    fun getHashCodeString(config: TealiumConfig, delimiter: String = ""): String {
+        return Integer.toHexString(
+                (config.accountName + delimiter +
+                        config.profileName + delimiter +
+                        config.environment.environment).hashCode())
+    }
+}

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.launch
 import java.util.*
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.collections.ArrayList
 
 /**
  * @param key - uniquely identifies this Tealium instance.
@@ -335,36 +334,16 @@ class Tealium @JvmOverloads constructor(val key: String, val config: TealiumConf
             val key = item.key
             val value = item.value
 
-            (value as? String)?.let {
-                dataLayer.putString(key, it, Expiry.FOREVER)
-            }
-            (value as? Boolean)?.let {
-                dataLayer.putBoolean(key, it, Expiry.FOREVER)
-            }?:
-            (value as? Double)?.let {
-                dataLayer.putDouble(key, it, Expiry.FOREVER)
-            }?:
-            (value as? Int)?.let {
-                dataLayer.putInt(key, it, Expiry.FOREVER)
-            }?:
-            (value as? Long)?.let {
-                dataLayer.putLong(key, it, Expiry.FOREVER)
-            }?:
-            if (value is Set<*>) {
-                value.firstOrNull()?.let {
-                    when(it) {
-                        is String -> {
-                            val stringArray: MutableList<String> = ArrayList<String>()
-                            value.forEach { anyValue ->
-                                anyValue?.let { stringValue ->
-                                    if (stringValue is String) {
-                                        stringArray.add(stringValue)
-                                    }
-                                }
-                            }
-                            dataLayer.putStringArray(key, stringArray.toTypedArray())
-                        }
-                    }
+            when (value) {
+                is String -> dataLayer.putString(key, value, Expiry.FOREVER)
+                is Boolean -> dataLayer.putBoolean(key, value, Expiry.FOREVER)
+                is Float -> dataLayer.putDouble(key, value.toDouble(), Expiry.FOREVER)
+                is Double -> dataLayer.putDouble(key, value, Expiry.FOREVER)
+                is Int -> dataLayer.putInt(key, value, Expiry.FOREVER)
+                is Long -> dataLayer.putLong(key, value, Expiry.FOREVER)
+                is Set<*> -> {
+                    val list = value.filterIsInstance<String>()
+                    dataLayer.putStringArray(key, list.toTypedArray(), Expiry.FOREVER)
                 }
             }
         }

--- a/tealiumlibrary/src/main/java/com/tealium/core/collection/AppCollectorConstants.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/collection/AppCollectorConstants.kt
@@ -1,6 +1,7 @@
 @file:JvmName("Constants")
 
 object AppCollectorConstants {
+    const val APP_UUID = "app_uuid"
     const val APP_RDNS = "app_rdns"
     const val APP_NAME = "app_name"
     const val APP_BUILD = "app_build"

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManagerConstants.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManagerConstants.kt
@@ -11,9 +11,7 @@ object ConsentManagerConstants {
     const val GRANT_FULL_CONSENT = "grant_full_consent"
     const val GRANT_PARTIAL_CONSENT = "grant_partial_consent"
     const val DECLINE_CONSENT = "decline_consent"
-}
 
-object ConsentManagerSPKey {
-    const val STATUS = "status"
-    const val CATEGORIES = "categories"
+    const val KEY_STATUS = "status"
+    const val KEY_CATEGORIES = "categories"
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentSharedPreferences.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentSharedPreferences.kt
@@ -1,8 +1,8 @@
 package com.tealium.core.consent
 import android.content.SharedPreferences
 import com.tealium.core.TealiumConfig
-import com.tealium.core.consent.ConsentManagerSPKey.STATUS
-import com.tealium.core.consent.ConsentManagerSPKey.CATEGORIES
+import com.tealium.core.consent.ConsentManagerConstants.KEY_STATUS
+import com.tealium.core.consent.ConsentManagerConstants.KEY_CATEGORIES
 
 /**
  * This class is responsible for the persistence of consent preferences as defined by [ConsentStatus]
@@ -15,19 +15,19 @@ internal class ConsentSharedPreferences(config: TealiumConfig) {
     var consentStatus: ConsentStatus = ConsentStatus.UNKNOWN
         get() {
             return ConsentStatus.consentStatus(
-                    sharedPreferences.getString(STATUS, ConsentStatus.default().value)!!
+                    sharedPreferences.getString(KEY_STATUS, ConsentStatus.default().value)!!
             )
         }
         set(value) {
             field = value
             sharedPreferences.edit()
-                    .putString(STATUS, field.value)
+                    .putString(KEY_STATUS, field.value)
                     .apply()
         }
 
     var consentCategories: Set<ConsentCategory>? = null
         get() {
-            return sharedPreferences.getStringSet(CATEGORIES, null)?.let {
+            return sharedPreferences.getStringSet(KEY_CATEGORIES, null)?.let {
                 ConsentCategory.consentCategories(it.filterNotNull().toSet())
             }
         }
@@ -35,10 +35,10 @@ internal class ConsentSharedPreferences(config: TealiumConfig) {
             field = value
             value?.let { categories ->
                 sharedPreferences.edit()
-                        .putStringSet(CATEGORIES, categories.map { category -> category.value }.toSet())
+                        .putStringSet(KEY_CATEGORIES, categories.map { category -> category.value }.toSet())
                         .apply()
             } ?: run {
-                sharedPreferences.edit().remove(CATEGORIES).apply()
+                sharedPreferences.edit().remove(KEY_CATEGORIES).apply()
             }
         }
 

--- a/tealiumlibrary/src/test/java/com/tealium/core/consent/ConsentManagerTest.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/consent/ConsentManagerTest.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.content.SharedPreferences
 import com.tealium.core.Environment
 import com.tealium.core.TealiumConfig
+import com.tealium.core.consent.ConsentManagerConstants.KEY_CATEGORIES
+import com.tealium.core.consent.ConsentManagerConstants.KEY_STATUS
 import com.tealium.core.messaging.EventRouter
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
@@ -42,9 +44,9 @@ class ConsentManagerTest {
         every { sharedPreferences.edit() } returns editor
         every { editor.apply() } just Runs
 
-        every { sharedPreferences.getString(ConsentManagerSPKey.STATUS, "unknown") } returns "unknown"
-        every { sharedPreferences.getStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns null
-        every { editor.putString(ConsentManagerSPKey.STATUS, "unknown") } returns editor
+        every { sharedPreferences.getString(KEY_STATUS, "unknown") } returns "unknown"
+        every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns null
+        every { editor.putString(KEY_STATUS, "unknown") } returns editor
 
         config = TealiumConfig(context, "test", "profile", Environment.QA)
         consentManager = ConsentManager(config, eventRouter, "visitor1234567890", mockk())
@@ -77,9 +79,9 @@ class ConsentManagerTest {
 
     @Test
     fun consentManagerNotConsentedNullConsentCategories() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "notConsented") } returns editor
+        every { editor.putString(KEY_STATUS, "notConsented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "notConsented"
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns editor
+        every { editor.putStringSet(KEY_CATEGORIES, null) } returns editor
         every { editor.remove(any()) } returns editor
         consentManager.userConsentStatus = ConsentStatus.NOT_CONSENTED
         assertEquals(ConsentStatus.NOT_CONSENTED, consentManager.userConsentStatus)
@@ -88,10 +90,10 @@ class ConsentManagerTest {
 
     @Test
     fun consentManagerSetSingleCategorySetsConsented() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "consented") } returns editor
+        every { editor.putString(KEY_STATUS, "consented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
-        every { sharedPreferences.getStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns setOf("engagement")
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, setOf("engagement")) } returns editor
+        every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns setOf("engagement")
+        every { editor.putStringSet(KEY_CATEGORIES, setOf("engagement")) } returns editor
         consentManager.userConsentCategories = setOf(ConsentCategory.ENGAGEMENT)
         assertEquals(ConsentStatus.CONSENTED, consentManager.userConsentStatus)
         assertTrue(consentManager.userConsentCategories?.contains(ConsentCategory.ENGAGEMENT)!!)
@@ -99,9 +101,9 @@ class ConsentManagerTest {
 
     @Test
     fun consentManagerSetCategoryNullSetsConsentStatusNotConsented() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "notConsented") } returns editor
+        every { editor.putString(KEY_STATUS, "notConsented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "notConsented"
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns editor
+        every { editor.putStringSet(KEY_CATEGORIES, null) } returns editor
         every { editor.remove(any()) } returns editor
         consentManager.userConsentCategories = null
         assertEquals(ConsentStatus.NOT_CONSENTED, consentManager.userConsentStatus)
@@ -110,9 +112,9 @@ class ConsentManagerTest {
 
     @Test
     fun consentManagerSetCategoryNullSetsConsentStatusUnknown() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "unknown") } returns editor
+        every { editor.putString(KEY_STATUS, "unknown") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "unknown"
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns editor
+        every { editor.putStringSet(KEY_CATEGORIES, null) } returns editor
         every { editor.remove(any()) } returns editor
         consentManager.userConsentStatus = ConsentStatus.UNKNOWN
         assertEquals(ConsentStatus.UNKNOWN, consentManager.userConsentStatus)
@@ -121,10 +123,10 @@ class ConsentManagerTest {
 
     @Test
     fun setUserConsentStatusConsentedSetsAllCategories() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "consented") } returns editor
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, ConsentCategory.ALL.map { it.value }.toMutableSet()) } returns editor
+        every { editor.putString(KEY_STATUS, "consented") } returns editor
+        every { editor.putStringSet(KEY_CATEGORIES, ConsentCategory.ALL.map { it.value }.toMutableSet()) } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
-        every { sharedPreferences.getStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns ConsentCategory.ALL.map { it.value }.toMutableSet()
+        every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns ConsentCategory.ALL.map { it.value }.toMutableSet()
         consentManager.userConsentStatus = ConsentStatus.CONSENTED
         assertEquals(ConsentStatus.CONSENTED, consentManager.userConsentStatus)
         assertEquals(15, consentManager.userConsentCategories?.count())
@@ -132,7 +134,7 @@ class ConsentManagerTest {
 
     @Test
     fun resetUserConsentPreferencesSuccess() {
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns editor
+        every { editor.putStringSet(KEY_CATEGORIES, null) } returns editor
         every { editor.remove(any()) } returns editor
         consentManager.reset()
         assertEquals(ConsentStatus.UNKNOWN, consentManager.userConsentStatus)
@@ -141,10 +143,10 @@ class ConsentManagerTest {
 
     @Test
     fun userPreferencesUpdateListener_Called() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "consented") } returns editor
+        every { editor.putString(KEY_STATUS, "consented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
-        every { sharedPreferences.getStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns setOf("engagement")
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, setOf("engagement")) } returns editor
+        every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns setOf("engagement")
+        every { editor.putStringSet(KEY_CATEGORIES, setOf("engagement")) } returns editor
         consentManager = ConsentManager(config, eventRouter, "", mockk(), ConsentPolicy.GDPR)
         consentManager.userConsentCategories = setOf(ConsentCategory.ENGAGEMENT)
 
@@ -156,10 +158,10 @@ class ConsentManagerTest {
 
     @Test
     fun userPreferencesUpdateListener_NotCalled() {
-        every { editor.putString(ConsentManagerSPKey.STATUS, "consented") } returns editor
+        every { editor.putString(KEY_STATUS, "consented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
-        every { sharedPreferences.getStringSet(ConsentManagerSPKey.CATEGORIES, null) } returns setOf("engagement")
-        every { editor.putStringSet(ConsentManagerSPKey.CATEGORIES, setOf("engagement")) } returns editor
+        every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns setOf("engagement")
+        every { editor.putStringSet(KEY_CATEGORIES, setOf("engagement")) } returns editor
         consentManager.userConsentCategories = setOf(ConsentCategory.ENGAGEMENT)
 
         // no policy == no updates.

--- a/tealiumlibrary/src/test/java/com/tealium/core/consent/ConsentSharedPreferencesTest.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/consent/ConsentSharedPreferencesTest.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import android.content.SharedPreferences
 import com.tealium.core.Environment
 import com.tealium.core.TealiumConfig
-import com.tealium.core.consent.ConsentManagerSPKey.STATUS
-import com.tealium.core.consent.ConsentManagerSPKey.CATEGORIES
+import com.tealium.core.consent.ConsentManagerConstants.KEY_STATUS
+import com.tealium.core.consent.ConsentManagerConstants.KEY_CATEGORIES
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import org.junit.Assert.assertEquals
@@ -44,14 +44,14 @@ class ConsentSharedPreferencesTest {
 
     @Test
     fun testConsentStatus_InitialValueIsUnknown() {
-        every { sharedPreferences.getString(STATUS, any()) } returns ConsentStatus.default().value
+        every { sharedPreferences.getString(KEY_STATUS, any()) } returns ConsentStatus.default().value
 
         assertEquals(ConsentStatus.UNKNOWN, consentSharedPreferences.consentStatus)
     }
 
     @Test
     fun testConsentStatus_InitialValueIsNotUnknown() {
-        every { sharedPreferences.getString(STATUS, any()) } returns ConsentStatus.NOT_CONSENTED.value
+        every { sharedPreferences.getString(KEY_STATUS, any()) } returns ConsentStatus.NOT_CONSENTED.value
 
         assertEquals(ConsentStatus.NOT_CONSENTED, consentSharedPreferences.consentStatus)
     }
@@ -61,19 +61,19 @@ class ConsentSharedPreferencesTest {
         every { editor.remove(any()) } returns editor
         consentSharedPreferences.consentCategories = null
 
-        verify { editor.remove(CATEGORIES) }
+        verify { editor.remove(KEY_CATEGORIES) }
     }
 
     @Test
     fun testConsentCategories_UpdatesStoredCategories() {
-        every { editor.putStringSet(CATEGORIES, any()) } returns editor
+        every { editor.putStringSet(KEY_CATEGORIES, any()) } returns editor
         consentSharedPreferences.consentCategories = setOf(
                 ConsentCategory.MONITORING,
                 ConsentCategory.CDP,
                 ConsentCategory.EMAIL)
 
         verify {
-            editor.putStringSet(CATEGORIES, setOf(
+            editor.putStringSet(KEY_CATEGORIES, setOf(
                 ConsentCategory.MONITORING.value,
                 ConsentCategory.CDP.value,
                 ConsentCategory.EMAIL.value))
@@ -82,14 +82,14 @@ class ConsentSharedPreferencesTest {
 
     @Test
     fun testConsentReset_GetsReset() {
-        every { editor.putString(STATUS, any()) } returns editor
+        every { editor.putString(KEY_STATUS, any()) } returns editor
         every { editor.remove(any()) } returns editor
 
         consentSharedPreferences.reset()
 
         verify {
-            editor.putString(STATUS, "unknown")
-            editor.remove(CATEGORIES)
+            editor.putString(KEY_STATUS, "unknown")
+            editor.remove(KEY_CATEGORIES)
         }
     }
 }


### PR DESCRIPTION
 - reworked some of the code
 - added some validation unit tests for consent/lifecycle/persistent data migration.
 - added missing `app_uuid` to the AppCollector (uses the datalayer to store rather than actually returning it on `collect()`