### PR TITLE
visitor service updates

### DIFF
--- a/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
+++ b/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
@@ -3,8 +3,6 @@ package com.tealium.mobile
 import android.app.Application
 import com.tealium.collectdispatcher.Collect
 import com.tealium.core.*
-import com.tealium.core.consent.ConsentPolicy
-import com.tealium.core.consent.consentManagerPolicy
 import com.tealium.core.validation.DispatchValidator
 import com.tealium.dispatcher.Dispatch
 import com.tealium.dispatcher.TealiumEvent
@@ -19,8 +17,7 @@ import com.tealium.remotecommanddispatcher.remotecommands.RemoteCommand
 import com.tealium.tagmanagementdispatcher.TagManagement
 import com.tealium.visitorservice.VisitorProfile
 import com.tealium.visitorservice.VisitorService
-import com.tealium.visitorservice.VisitorServiceDelegate
-import com.tealium.visitorservice.visitorService
+import com.tealium.visitorservice.VisitorUpdatedListener
 
 object TealiumHelper {
     lateinit var instance: Tealium
@@ -40,11 +37,11 @@ object TealiumHelper {
 
         instance = Tealium("instance_1", config) {
             consentManager.enabled = true
-            visitorService?.delegate = object : VisitorServiceDelegate {
-                override fun didUpdate(visitorProfile: VisitorProfile) {
+            events.subscribe(object : VisitorUpdatedListener {
+                override fun onVisitorUpdated(visitorProfile: VisitorProfile) {
                     Logger.dev("--", "did update vp with $visitorProfile")
                 }
-            }
+            })
 
             remoteCommands?.add(localJsonCommand)
             remoteCommands?.add(webViewRemoteCommand)

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -193,7 +193,7 @@ class Tealium @JvmOverloads constructor(val key: String, val config: TealiumConf
 
         dispatchSendCallbacks = DispatchSendCallbacks(eventRouter) // required by dispatchers.
 
-        context = TealiumContext(config, visitorId, logger, dataLayer, networkClient, events, this)
+        context = TealiumContext(config, visitorId, logger, dataLayer, networkClient, events as MessengerService, this)
         collectors = mutableSetOf(TealiumCollector(context), SessionCollector(session.id), dataLayer).union(initializeCollectors(config.collectors))
         validators = initializeValidators(config.validators)
         dispatchers = initializeDispatchers(config.dispatchers)

--- a/tealiumlibrary/src/main/java/com/tealium/core/TealiumContext.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/TealiumContext.kt
@@ -1,6 +1,6 @@
 package com.tealium.core
 
-import com.tealium.core.messaging.Subscribable
+import com.tealium.core.messaging.MessengerService
 import com.tealium.core.persistence.DataLayer
 import com.tealium.core.network.NetworkClient
 import com.tealium.dispatcher.Dispatch
@@ -13,7 +13,7 @@ data class TealiumContext(val config: TealiumConfig,
                           val log: Logging,
                           val dataLayer: DataLayer,
                           val httpClient: NetworkClient,
-                          val events: Subscribable,
+                          val events: MessengerService,
                           val tealium: Tealium) {
 
     /**

--- a/tealiumlibrary/src/main/java/com/tealium/core/messaging/MessengerService.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/messaging/MessengerService.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 // Facade around the EventRouter to allow users to subscribe to events and only send public ones.
-internal class MessengerService(private val eventRouter: EventRouter,
+class MessengerService(private val eventRouter: EventRouter,
                                 private val background: CoroutineScope):
         Subscribable by eventRouter {
 

--- a/visitorservice/build.gradle
+++ b/visitorservice/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_android_version"
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.5"
     testImplementation "org.robolectric:robolectric:4.3.1"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/visitorservice/src/main/java/com/tealium/visitorservice/CurrentVisit.kt
+++ b/visitorservice/src/main/java/com/tealium/visitorservice/CurrentVisit.kt
@@ -22,6 +22,48 @@ data class CurrentVisit(
 
     companion object {
 
+        fun toJson(currentVisit: CurrentVisit): JSONObject {
+            val json = JSONObject()
+
+            currentVisit.dates?.let {
+                json.put(KEY_DATES, JSONObject(it))
+            }
+
+            currentVisit.booleans?.let {
+                json.put(KEY_FLAGS, JSONObject(it))
+            }
+
+            currentVisit.arraysOfBooleans?.let {
+                json.put(KEY_FLAG_LISTS, JSONObject(it))
+            }
+
+            currentVisit.numbers?.let {
+                json.put(KEY_METRICS, JSONObject(it))
+            }
+
+            currentVisit.arraysOfNumbers?.let {
+                json.put(KEY_METRIC_LISTS, JSONObject(it))
+            }
+
+            currentVisit.tallies?.let {
+                json.put(KEY_METRIC_SETS, JSONObject(it))
+            }
+
+            currentVisit.strings?.let {
+                json.put(KEY_PROPERTIES, JSONObject(it))
+            }
+
+            currentVisit.arraysOfStrings?.let {
+                json.put(KEY_PROPERTY_LISTS, JSONObject(it))
+            }
+
+            currentVisit.setsOfStrings?.let {
+                json.put(KEY_PROPERTY_SETS, JSONObject(it))
+            }
+
+            return json
+        }
+
         fun fromJson(json: JSONObject): CurrentVisit {
             return CurrentVisit().apply {
                 createdAt = json.optLong(KEY_CREATED_AT)

--- a/visitorservice/src/main/java/com/tealium/visitorservice/TealiumConfigVisitorService.kt
+++ b/visitorservice/src/main/java/com/tealium/visitorservice/TealiumConfigVisitorService.kt
@@ -17,7 +17,7 @@ var TealiumConfig.overrideVisitorServiceUrl: String?
     }
 
 /**
- * Sets the length of time to use between requesting an updated Visitor Profile
+ * Sets the length of time in Seconds to use between requesting an updated Visitor Profile
  */
 var TealiumConfig.visitorServiceRefreshInterval: Long?
     get() = options[VISITOR_SERVICE_REFRESH_INTERVAL] as? Long

--- a/visitorservice/src/main/java/com/tealium/visitorservice/VisitorProfile.kt
+++ b/visitorservice/src/main/java/com/tealium/visitorservice/VisitorProfile.kt
@@ -40,6 +40,60 @@ data class VisitorProfile(
         var currentVisit: CurrentVisit? = null) {
 
     companion object {
+        fun toJson(visitorProfile: VisitorProfile): JSONObject {
+            val json = JSONObject()
+
+            visitorProfile.audiences?.let {
+                json.put(KEY_AUDIENCES, JSONObject(it))
+            }
+
+            visitorProfile.badges?.let {
+                json.put(KEY_BADGES, JSONObject(it))
+            }
+
+            visitorProfile.dates?.let {
+                json.put(KEY_DATES, JSONObject(it))
+            }
+
+            visitorProfile.booleans?.let {
+                json.put(KEY_FLAGS, JSONObject(it))
+            }
+
+            visitorProfile.arraysOfBooleans?.let {
+                json.put(KEY_FLAG_LISTS, JSONObject(it))
+            }
+
+            visitorProfile.numbers?.let {
+                json.put(KEY_METRICS, JSONObject(it))
+            }
+
+            visitorProfile.arraysOfNumbers?.let {
+                json.put(KEY_METRIC_LISTS, JSONObject(it))
+            }
+
+            visitorProfile.tallies?.let {
+                json.put(KEY_METRIC_SETS, JSONObject(it))
+            }
+
+            visitorProfile.strings?.let {
+                json.put(KEY_PROPERTIES, JSONObject(it))
+            }
+
+            visitorProfile.arraysOfStrings?.let {
+                json.put(KEY_PROPERTY_LISTS, JSONObject(it))
+            }
+
+            visitorProfile.setsOfStrings?.let {
+                json.put(KEY_PROPERTY_SETS, JSONObject(it))
+            }
+
+            visitorProfile.currentVisit?.let {
+                json.put(KEY_CURRENT_VISIT, CurrentVisit.toJson(it))
+            }
+
+            return json
+        }
+
         fun fromJson(json: JSONObject): VisitorProfile {
             val visitorProfile = VisitorProfile()
 

--- a/visitorservice/src/main/java/com/tealium/visitorservice/VisitorProfileManager.kt
+++ b/visitorservice/src/main/java/com/tealium/visitorservice/VisitorProfileManager.kt
@@ -1,0 +1,128 @@
+package com.tealium.visitorservice
+
+import com.tealium.core.*
+import com.tealium.core.messaging.BatchDispatchSendListener
+import com.tealium.core.messaging.DispatchSendListener
+import com.tealium.core.messaging.ExternalListener
+import com.tealium.core.messaging.Messenger
+import com.tealium.core.network.ResourceRetriever
+import com.tealium.dispatcher.Dispatch
+import kotlinx.coroutines.delay
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+class VisitorUpdatedMessenger(private val visitorProfile: VisitorProfile) : Messenger<VisitorUpdatedListener>(VisitorUpdatedListener::class) {
+    override fun deliver(listener: VisitorUpdatedListener) {
+        listener.onVisitorUpdated(visitorProfile)
+    }
+}
+
+interface VisitorUpdatedListener : ExternalListener {
+    fun onVisitorUpdated(visitorProfile: VisitorProfile)
+}
+
+class VisitorProfileManager(private val context: TealiumContext,
+                            private val refreshInterval: Long =
+                                    context.config.visitorServiceRefreshInterval
+                                            ?: DEFAULT_REFRESH_INTERVAL,
+                            private val visitorServiceUrl: String =
+                                    context.config.overrideVisitorServiceUrl
+                                            ?: "https://visitor-service.tealiumiq.com/${context.config.accountName}/${context.config.profileName}/${context.visitorId}",
+                            private val loader: Loader = JsonLoader(context.config.application)) : DispatchSendListener, BatchDispatchSendListener {
+
+    private val file = File(context.config.tealiumDirectory, VISITOR_PROFILE_FILENAME)
+
+    val isUpdating = AtomicBoolean(false)
+    private var lastUpdate: Long = -1L
+    private val resourceRetriever: ResourceRetriever
+
+    var visitorProfile: VisitorProfile = loadCachedProfile() ?: VisitorProfile()
+        private set(value) {
+            field = value
+            context.events.send(VisitorUpdatedMessenger(value))
+        }
+
+    init {
+        resourceRetriever = ResourceRetriever(context.config, visitorServiceUrl, context.httpClient).apply {
+            useIfModifed = false
+            maxRetries = 1
+            refreshInterval = 0
+        }
+    }
+
+    fun loadCachedProfile(): VisitorProfile? {
+        return loader.loadFromFile(file)?.let {
+            return try {
+                val jsonObject = JSONObject(it)
+                VisitorProfile.fromJson(jsonObject)
+            } catch (jex: JSONException) {
+                Logger.dev(BuildConfig.TAG, "Failed to read cached visitor profile.")
+                null
+            }
+        }
+    }
+
+    fun saveVisitorProfile(visitorProfile: VisitorProfile) {
+        file.writeText(VisitorProfile.toJson(visitorProfile).toString(), Charsets.UTF_8)
+    }
+
+    override suspend fun onDispatchSend(dispatch: Dispatch) {
+        updateProfile()
+    }
+
+    override suspend fun onBatchDispatchSend(dispatches: List<Dispatch>) {
+        updateProfile()
+    }
+
+    suspend fun updateProfile() {
+        if (refreshIntervalReached()) {
+            requestVisitorProfile()
+        } else {
+            Logger.dev(BuildConfig.TAG, "Visitor Profile refresh interval not reached, will not update.")
+        }
+    }
+
+    suspend fun requestVisitorProfile() {
+        // no need if it's already being updated, but we won't adhere to the refreshInterval here.
+        if (isUpdating.compareAndSet(false, true)) {
+            for (i in 1..5) {
+                Logger.dev(BuildConfig.TAG, "Fetching visitor profile for ${context.visitorId}.")
+
+                val json = resourceRetriever.fetch()
+                if (json != null && json != "{}") {
+                    Logger.dev(BuildConfig.TAG, "Fetched visitor profile: $json.")
+
+                    val newProfile = VisitorProfile.fromJson(JSONObject(json))
+                    if (visitorProfile.totalEventCount != newProfile.totalEventCount) {
+                        lastUpdate = System.currentTimeMillis()
+                        saveVisitorProfile(newProfile)
+                        visitorProfile = newProfile
+                        break
+                    } else {
+                        Logger.dev(BuildConfig.TAG, "Visitor Profile found but it was stale.")
+                    }
+                } else {
+                    Logger.dev(BuildConfig.TAG, "Invalid visitor profile found.")
+                }
+                // back off a bit
+                delay(750L * i)
+            }
+            isUpdating.set(false)
+
+        } else {
+            Logger.dev(BuildConfig.TAG, "Visitor profile is already being updated.")
+        }
+    }
+
+    private fun refreshIntervalReached(): Boolean {
+        return lastUpdate + TimeUnit.SECONDS.toMillis(refreshInterval) <= System.currentTimeMillis()
+    }
+
+    companion object {
+        const val VISITOR_PROFILE_FILENAME = "visitor_profile.json"
+        const val DEFAULT_REFRESH_INTERVAL = 300L
+    }
+}

--- a/visitorservice/src/test/java/com/tealium/visitorservice/VisitorProfileManagerTest.kt
+++ b/visitorservice/src/test/java/com/tealium/visitorservice/VisitorProfileManagerTest.kt
@@ -1,0 +1,290 @@
+package com.tealium.visitorservice
+
+import android.app.Application
+import com.tealium.core.Environment
+import com.tealium.core.JsonLoader
+import com.tealium.core.TealiumConfig
+import com.tealium.core.TealiumContext
+import com.tealium.core.messaging.MessengerService
+import com.tealium.core.network.HttpClient
+import com.tealium.core.network.ResourceRetriever
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlinx.coroutines.delay
+import org.junit.Assert.*
+
+@RunWith(RobolectricTestRunner::class)
+class VisitorProfileManagerTest {
+
+    @MockK
+    private lateinit var mockApplication: Application
+
+    @MockK
+    private lateinit var mockContext: TealiumContext
+
+    @MockK
+    private lateinit var mockConfig: TealiumConfig
+
+    @MockK
+    private lateinit var mockHttpClient: HttpClient
+
+    @MockK
+    private lateinit var mockResourceRetriever: ResourceRetriever
+
+    @MockK
+    private lateinit var mockLoader: JsonLoader
+
+    @MockK
+    private lateinit var mockMessengerService: MessengerService
+
+    private lateinit var directory: File
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        directory = File("test")
+        directory.mkdir()
+
+        every { mockContext.config } returns mockConfig
+        every { mockContext.events } returns mockMessengerService
+        every { mockContext.visitorId } returns "visitorId"
+        every { mockContext.httpClient } returns mockHttpClient
+
+        every { mockConfig.application } returns mockApplication
+        every { mockConfig.accountName } returns "test-account"
+        every { mockConfig.profileName } returns "test-profile"
+        every { mockConfig.environment } returns Environment.DEV
+        every { mockConfig.tealiumDirectory } returns directory
+        every { mockConfig.overrideVisitorServiceUrl } returns null
+        every { mockConfig.visitorServiceRefreshInterval } returns null
+
+        coEvery { mockMessengerService.send(any<VisitorUpdatedMessenger>()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        directory.deleteRecursively()
+        unmockkObject(VisitorProfile.Companion)
+    }
+
+    @Test
+    fun persistence_IsLoadedFromDiskWhenNotNull() {
+        every { mockLoader.loadFromFile(any()) } returns "{}"
+        val visitorProfileManager = VisitorProfileManager(mockContext, loader = mockLoader)
+
+        assertNotNull(visitorProfileManager.loadCachedProfile())
+        assertNotNull(visitorProfileManager.visitorProfile)
+    }
+
+    @Test
+    fun persistence_ReturnsNullWhenNoFile() {
+        every { mockLoader.loadFromFile(any()) } returns null
+        val visitorProfileManager = VisitorProfileManager(mockContext, loader = mockLoader)
+
+        assertNull(visitorProfileManager.loadCachedProfile())
+        assertNotNull(visitorProfileManager.visitorProfile)
+    }
+
+    @Test
+    fun fetching_ShouldNotFetchWhenAlreadyUpdating() {
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+        visitorProfileManager.isUpdating.set(true)
+
+        runBlocking {
+            visitorProfileManager.requestVisitorProfile()
+        }
+        coVerify(exactly = 0) {
+            mockHttpClient.get(any())
+        }
+    }
+
+    @Test
+    fun fetching_ShouldNotFetchWhenIntervalNotReached() {
+        coEvery { mockHttpClient.get(any()) } returns validExampleProfileString
+
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+
+        runBlocking {
+            visitorProfileManager.onBatchDispatchSend(mockk())
+            visitorProfileManager.onDispatchSend(mockk())
+            visitorProfileManager.updateProfile()
+        }
+        coVerify(exactly = 1) {
+            mockHttpClient.get(any())
+        }
+    }
+
+    @Test
+    fun fetching_ShouldRetryFiveTimesOnly() = runBlocking {
+        coEvery { mockHttpClient.get(any()) } returnsMany listOf(null, null, "{}", "{}", validExampleProfileString, null)
+
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+
+        runBlocking {
+            visitorProfileManager.requestVisitorProfile()
+        }
+        coVerify(exactly = 5) {
+            mockHttpClient.get(any())
+        }
+    }
+
+    @Test
+    fun fetching_ShouldBreakWhenFoundValidUpdatedProfile() = runBlocking {
+        coEvery { mockHttpClient.get(any()) } returnsMany listOf(null, "{}", validExampleProfileString, null)
+
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+
+        runBlocking {
+            visitorProfileManager.requestVisitorProfile()
+        }
+        coVerify(exactly = 3) {
+            mockHttpClient.get(any())
+        }
+    }
+
+    @Test
+    fun updated_ShouldNotSendUpdateWhenEventCountSame() {
+        mockkObject(VisitorProfile.Companion)
+        every { VisitorProfile.Companion.fromJson(any()) } returnsMany listOf(VisitorProfile(totalEventCount = 0), VisitorProfile(totalEventCount = 0))
+        coEvery { mockHttpClient.get(any()) } returns validExampleProfileString
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+
+        runBlocking {
+            assertEquals(0, visitorProfileManager.visitorProfile.totalEventCount)
+            visitorProfileManager.requestVisitorProfile()
+        }
+        verify(exactly = 0) {
+            mockMessengerService.send(any<VisitorUpdatedMessenger>())
+        }
+        assertEquals(0, visitorProfileManager.visitorProfile.totalEventCount)
+    }
+
+    @Test
+    fun updated_ShouldSendUpdateWhenEventCountDifferent() {
+        mockkObject(VisitorProfile.Companion)
+        every { VisitorProfile.Companion.fromJson(any()) } returnsMany listOf(VisitorProfile(totalEventCount = 0), VisitorProfile(totalEventCount = 1))
+        coEvery { mockHttpClient.get(any()) } returns validExampleProfileString
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+        assertEquals(0, visitorProfileManager.visitorProfile.totalEventCount)
+
+        runBlocking {
+            visitorProfileManager.requestVisitorProfile()
+        }
+        verify(exactly = 1) {
+            mockMessengerService.send(any<VisitorUpdatedMessenger>())
+        }
+        assertEquals(1, visitorProfileManager.visitorProfile.totalEventCount)
+    }
+
+    @Test
+    fun updated_ShouldNotSendUpdateWhenInvalidProfile() {
+        coEvery { mockHttpClient.get(any()) } returns "{}"
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+        assertEquals(0, visitorProfileManager.visitorProfile.totalEventCount)
+        runBlocking {
+            visitorProfileManager.requestVisitorProfile()
+        }
+        verify(exactly = 0) {
+            mockMessengerService.send(any<VisitorUpdatedMessenger>())
+        }
+        assertEquals(0, visitorProfileManager.visitorProfile.totalEventCount)
+    }
+
+    @Test
+    fun config_ShouldUseConfiguredUrlWhenProvided() {
+        every { mockConfig.overrideVisitorServiceUrl } returns "https://my.url.com"
+        coEvery { mockHttpClient.get(any()) } returns validExampleProfileString
+        val visitorProfileManager = VisitorProfileManager(mockContext)
+
+        runBlocking {
+            visitorProfileManager.requestVisitorProfile()
+        }
+        coVerify {
+            mockHttpClient.get("https://my.url.com")
+        }
+    }
+
+    @Test
+    fun config_ShouldUseConfiguredIntervalWhenProvided() {
+        every { mockConfig.visitorServiceRefreshInterval } returns 3L
+        coEvery { mockHttpClient.get(any()) } returns validExampleProfileString
+        val visitorProfileManager = spyk(VisitorProfileManager(mockContext))
+
+        runBlocking {
+            visitorProfileManager.onBatchDispatchSend(mockk())
+            delay(1000)
+            visitorProfileManager.onDispatchSend(mockk()) // should be skipped
+            delay(4000)
+            visitorProfileManager.updateProfile()
+        }
+        coVerify {
+            visitorProfileManager.onBatchDispatchSend(any())
+            visitorProfileManager.updateProfile()
+            visitorProfileManager.requestVisitorProfile()
+
+            visitorProfileManager.onDispatchSend(any())
+            visitorProfileManager.updateProfile()
+
+            visitorProfileManager.updateProfile()
+            visitorProfileManager.requestVisitorProfile()
+        }
+    }
+
+    private val validExampleProfileString = """
+        {
+            "badges":{
+                "5097":true
+            },
+            "dates":{
+                "23":1598371096000,
+                "24":1598371096000
+            },
+            "metrics":{
+                "22":6,
+                "5121":6,
+                "15":1,
+                "28":0,
+                "21":1
+            },
+            "properties":{
+                "profile":"android",
+                "account":"tealiummobile",
+                "17":"https:\\/\\/tags.tiqcdn.com\\/utag\\/tealiummobile\\/android\\/dev\\/mobile.html"
+            },
+            "current_visit":{
+                "dates":{
+                    "10":1598371096000
+                },
+                "flags":{
+                    "14":true
+                },
+                "metrics":{
+                    "7":6
+                },
+                "properties":{
+                    "45":"Android",
+                    "46":"Android",
+                    "47":"mobile application"
+                },
+                "property_sets":{
+                    "50":[
+                        "Android"
+                    ],
+                    "51":[
+                        "Android"
+                    ],
+                    "52":[
+                        "mobile application"
+                    ]
+                }
+                
+            }
+        }""".trimIndent()
+}


### PR DESCRIPTION
Couple of updates
 - Moved the bulk of the VS logic so a separate, more testable, class
 - Implemented configurable refreshInterval support
 - Added auto-fetch on each event (subject to refreshInterval checks)
    - manually calling `requestVisitorProfile()` will not adhere to the refreshInterval
 - Added persistence, so that there's a cached version available on launch.
 - Added test coverage to the VS 
 - Switched from visitorServiceDelegate -> VisitorUpdatedListener to be in keeping with the rest of the modules.