### PR TITLE
single instance common collectors

### DIFF
--- a/hosteddatalayer/src/main/java/com/tealium/hosteddatalayer/HostedDataLayer.kt
+++ b/hosteddatalayer/src/main/java/com/tealium/hosteddatalayer/HostedDataLayer.kt
@@ -13,7 +13,7 @@ import org.json.JSONObject
  */
 class HostedDataLayer(private val config: TealiumConfig,
                       private val dataLayerStorage: DataLayerStorage = DataLayerStore(config),
-                      private val httpClient: NetworkClient = HttpClient(config, connectivity = ConnectivityRetriever(config.application)))
+                      private val httpClient: NetworkClient = HttpClient(config, connectivity = ConnectivityRetriever.getInstance(config.application)))
     : Module, Transformer, DispatchValidator {
 
     override val name: String

--- a/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
+++ b/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
@@ -11,8 +11,8 @@ import com.tealium.core.TealiumConfig
 import com.tealium.core.TealiumContext
 import com.tealium.core.messaging.AfterDispatchSendCallbacks
 import com.tealium.core.messaging.LibrarySettingsUpdatedListener
-import com.tealium.core.messaging.NewSessionListener
 import com.tealium.core.messaging.SessionStartedListener
+import com.tealium.core.network.Connectivity
 import com.tealium.core.network.ConnectivityRetriever
 import com.tealium.core.settings.LibrarySettings
 import kotlinx.coroutines.CoroutineScope
@@ -23,11 +23,11 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class WebViewLoader(private val context: TealiumContext,
                     private val urlString: String,
-                    private val afterDispatchSendCallbacks: AfterDispatchSendCallbacks)
+                    private val afterDispatchSendCallbacks: AfterDispatchSendCallbacks,
+                    private val connectivityRetriever: Connectivity = ConnectivityRetriever.getInstance(context.config.application))
     : LibrarySettingsUpdatedListener,
         SessionStartedListener {
 
-    val connectivityRetriever = ConnectivityRetriever(context.config.application)
     val isWebViewLoaded = AtomicBoolean(false)
     var lastUrlLoadTimestamp = Long.MIN_VALUE
     private var isWifiOnlySending = false

--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/collection/CollectorTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/collection/CollectorTests.kt
@@ -179,4 +179,19 @@ class CollectorTestsAndroid {
             assertNotNull(factory.create(tealiumContext))
         }
     }
+
+    @Test
+    fun testSingletonsCreateOnlyOneInstance() {
+        val connectivityCollector1 = ConnectivityCollector.create(tealiumContext)
+        val connectivityCollector2 = ConnectivityCollector.create(tealiumContext)
+        assertSame(connectivityCollector1, connectivityCollector2)
+
+        val deviceCollector1 = DeviceCollector.create(tealiumContext)
+        val deviceCollector2 = DeviceCollector.create(tealiumContext)
+        assertSame(deviceCollector1, deviceCollector2)
+
+        val timeCollector1 = TimeCollector.create(tealiumContext)
+        val timeCollector2 = TimeCollector.create(tealiumContext)
+        assertSame(deviceCollector1, deviceCollector2)
+    }
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/Logger.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Logger.kt
@@ -37,7 +37,7 @@ interface Logging {
     fun prod(tag: String, msg: String)
 }
 
-class Logger(val config: TealiumConfig) {
+class Logger private constructor(val config: TealiumConfig) {
 
     val context: Context = config.application
 

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -189,7 +189,7 @@ class Tealium @JvmOverloads constructor(val key: String, val config: TealiumConf
      * Reports as ready once it's completed by calling [onInstanceReady].
      */
     private fun bootstrap() {
-        connectivity = ConnectivityRetriever(config.application)
+        connectivity = ConnectivityRetriever.getInstance(config.application)
         dispatchStore = DispatchStorage(databaseHelper, "dispatches")
 
         dispatchSendCallbacks = DispatchSendCallbacks(eventRouter) // required by dispatchers.

--- a/tealiumlibrary/src/main/java/com/tealium/core/collection/DeviceCollector.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/collection/DeviceCollector.kt
@@ -90,15 +90,10 @@ class DeviceCollector private constructor(context: Context) : Collector, DeviceD
     }
 
     companion object : CollectorFactory {
+        @Volatile private var instance: Collector? = null
 
-        private lateinit var applicationContext: Context
-        private val instance: Collector by lazy {
-            DeviceCollector(applicationContext)
-        }
-
-        override fun create(context: TealiumContext): Collector {
-            applicationContext = context.config.application.applicationContext
-            return instance
+        override fun create(context: TealiumContext): Collector = instance ?: synchronized(this){
+            instance ?: DeviceCollector(context.config.application).also { instance = it }
         }
     }
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/collection/TimeCollector.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/collection/TimeCollector.kt
@@ -52,8 +52,10 @@ class TimeCollector : Collector, TimeData {
     }
 
     companion object : CollectorFactory {
-        override fun create(context: TealiumContext): Collector {
-            return TimeCollector()
+        @Volatile private var instance: TimeCollector? = null
+
+        override fun create(context: TealiumContext): Collector = instance ?: synchronized(this) {
+            instance ?: TimeCollector()
         }
     }
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
@@ -27,7 +27,7 @@ class ConsentManager(private val config: TealiumConfig,
 
     private val consentLoggingUrl = config.consentManagerLoggingUrl
             ?: "https://collect.tealiumiq.com/event"
-    private val connectivity = ConnectivityRetriever(config.application)
+    private val connectivity = ConnectivityRetriever.getInstance(config.application)
     private val consentSharedPreferences = ConsentSharedPreferences(config)
     private val consentManagementPolicy: ConsentManagementPolicy?
     private val httpClient: NetworkClient by lazy { HttpClient(config, connectivity) }

--- a/tealiumlibrary/src/main/java/com/tealium/core/network/HttpClient.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/network/HttpClient.kt
@@ -18,7 +18,7 @@ import java.util.zip.GZIPOutputStream
 import javax.net.ssl.HttpsURLConnection
 
 class HttpClient(var config: TealiumConfig,
-                 override var connectivity: Connectivity = ConnectivityRetriever(config.application),
+                 override var connectivity: Connectivity = ConnectivityRetriever.getInstance(config.application),
                  override var networkClientListener: NetworkClientListener? = null) : NetworkClient {
 
     private val dateFormat: SimpleDateFormat = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.ROOT)


### PR DESCRIPTION
 - changes some common collectors to thread-safe (double checked) singleton instances so they can be shared between multiple Tealium instances.
 - some test updates to accommodate the changes too.
 - minor Android API fix in the ConnectivityCollector too.