### PR TITLE
privatised tealium

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -12,6 +12,7 @@ android {
         versionCode 1
         versionName "1.0"
         buildConfigField 'String', 'TAG', "\"App\""
+        buildConfigField 'String', 'TEALIUM_INSTANCE', "\"main\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/mobile/src/main/java/com/tealium/fragments/ConsentFragment.kt
+++ b/mobile/src/main/java/com/tealium/fragments/ConsentFragment.kt
@@ -5,9 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.tealium.core.Tealium
 import com.tealium.core.consent.ConsentCategory
 import com.tealium.core.consent.ConsentStatus
-import com.tealium.mobile.TealiumHelper
+import com.tealium.mobile.BuildConfig
 import com.tealium.mobile.R
 import kotlinx.android.synthetic.main.fragment_consent.*
 
@@ -37,19 +38,19 @@ class ConsentFragment : Fragment() {
     }
 
     private fun onConsented() {
-       TealiumHelper.instance.consentManager.userConsentStatus = ConsentStatus.CONSENTED
+        Tealium[BuildConfig.TEALIUM_INSTANCE]?.consentManager?.userConsentStatus = ConsentStatus.CONSENTED
     }
 
     private fun onNotConsented() {
-       TealiumHelper.instance.consentManager.userConsentStatus = ConsentStatus.NOT_CONSENTED
+        Tealium[BuildConfig.TEALIUM_INSTANCE]?.consentManager?.userConsentStatus = ConsentStatus.NOT_CONSENTED
     }
 
     private fun onResetConsentStatus() {
-       TealiumHelper.instance.consentManager.reset()
+        Tealium[BuildConfig.TEALIUM_INSTANCE]?.consentManager?.reset()
     }
 
     private fun onCategoriesButton() {
-       TealiumHelper.instance.consentManager.userConsentCategories = setOf(
+        Tealium[BuildConfig.TEALIUM_INSTANCE]?.consentManager?.userConsentCategories = setOf(
                 ConsentCategory.ANALYTICS,
                 ConsentCategory.BIG_DATA
         )

--- a/mobile/src/main/java/com/tealium/fragments/HostedDataLayerFragment.kt
+++ b/mobile/src/main/java/com/tealium/fragments/HostedDataLayerFragment.kt
@@ -5,8 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.tealium.core.Tealium
 import com.tealium.hosteddatalayer.hostedDataLayer
-import com.tealium.mobile.TealiumHelper
+import com.tealium.mobile.BuildConfig
 import com.tealium.mobile.R
 import kotlinx.android.synthetic.main.fragment_hosted_data_layer.*
 import kotlinx.coroutines.GlobalScope
@@ -27,7 +28,7 @@ class HostedDataLayerFragment : Fragment() {
 
     private fun onClearCache() {
         GlobalScope.launch {
-            TealiumHelper.instance.hostedDataLayer?.clearCache()
+            Tealium[BuildConfig.TEALIUM_INSTANCE]?.hostedDataLayer?.clearCache()
         }
     }
 }

--- a/mobile/src/main/java/com/tealium/fragments/LocationFragment.kt
+++ b/mobile/src/main/java/com/tealium/fragments/LocationFragment.kt
@@ -9,10 +9,10 @@ import android.view.ViewGroup
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.tealium.core.Tealium
 import com.tealium.location.location
-import com.tealium.mobile.TealiumHelper
+import com.tealium.mobile.BuildConfig
 import com.tealium.mobile.R
-import com.tealium.visitorservice.visitorService
 import kotlinx.android.synthetic.main.fragment_location.*
 
 class LocationFragment : Fragment() {
@@ -29,18 +29,18 @@ class LocationFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         button_startLocation.setOnClickListener {
-           TealiumHelper.instance.location?.startLocationTracking(true, 5000)
+            Tealium[BuildConfig.TEALIUM_INSTANCE]?.location?.startLocationTracking(true, 5000)
         }
     }
 
     private fun requestLocationPermission() {
         activity?.let {
             if (ContextCompat.checkSelfPermission(it.applicationContext, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(it, Array<String>(1){Manifest.permission.ACCESS_FINE_LOCATION}, FINE_LOCATION_REQUEST_CODE)
+                ActivityCompat.requestPermissions(it, Array<String>(1) { Manifest.permission.ACCESS_FINE_LOCATION }, FINE_LOCATION_REQUEST_CODE)
             }
 
             if (ContextCompat.checkSelfPermission(it.applicationContext, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(it, Array<String>(1){Manifest.permission.ACCESS_COARSE_LOCATION}, COARSE_LOCATION_REQUEST_CODE)
+                ActivityCompat.requestPermissions(it, Array<String>(1) { Manifest.permission.ACCESS_COARSE_LOCATION }, COARSE_LOCATION_REQUEST_CODE)
             }
         }
     }

--- a/mobile/src/main/java/com/tealium/fragments/VisitorServiceFragment.kt
+++ b/mobile/src/main/java/com/tealium/fragments/VisitorServiceFragment.kt
@@ -5,7 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.tealium.mobile.TealiumHelper
+import com.tealium.core.Tealium
+import com.tealium.mobile.BuildConfig
 import com.tealium.mobile.R
 import com.tealium.visitorservice.visitorService
 import kotlinx.android.synthetic.main.fragment_visitor_service.*
@@ -28,7 +29,7 @@ class VisitorServiceFragment : Fragment() {
     private fun onFetchProfile() {
         GlobalScope.launch {
             println("fetch profile")
-            TealiumHelper.instance.visitorService?.requestVisitorProfile()
+            Tealium[BuildConfig.TEALIUM_INSTANCE]?.visitorService?.requestVisitorProfile()
         }
     }
 }

--- a/mobile/src/main/java/com/tealium/mobile/MainActivity.kt
+++ b/mobile/src/main/java/com/tealium/mobile/MainActivity.kt
@@ -4,9 +4,6 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.Fragment
-import com.tealium.core.Tealium
-import com.tealium.dispatcher.TealiumEvent
-import com.tealium.dispatcher.TealiumView
 import com.tealium.fragments.*
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.coroutines.CoroutineScope
@@ -17,9 +14,6 @@ class MainActivity : AppCompatActivity(), CoroutineScope by CoroutineScope(Dispa
     companion object {
         private val TAG = MainActivity::class.qualifiedName
     }
-
-    private val tealium: Tealium
-        get() = TealiumHelper.instance
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate")
@@ -45,7 +39,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope by CoroutineScope(Dispa
     }
 
     private fun onTrack() {
-        TealiumHelper.trackEvent("event1",  mapOf("key1" to "value1", "key2" to 2))
+        TealiumHelper.trackEvent("event1", mapOf("key1" to "value1", "key2" to 2))
 
     }
 

--- a/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
+++ b/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
@@ -1,10 +1,10 @@
 package com.tealium.mobile
 
 import android.app.Application
-import android.os.Bundle
 import com.tealium.collectdispatcher.Collect
 import com.tealium.core.*
 import com.tealium.core.consent.ConsentPolicy
+import com.tealium.core.consent.consentManagerEnabled
 import com.tealium.core.consent.consentManagerPolicy
 import com.tealium.core.validation.DispatchValidator
 import com.tealium.dispatcher.Dispatch
@@ -24,7 +24,6 @@ import com.tealium.visitorservice.VisitorServiceDelegate
 import com.tealium.visitorservice.visitorService
 
 object TealiumHelper {
-    lateinit var instance: Tealium
 
     fun init(application: Application) {
         val config = TealiumConfig(application,
@@ -37,10 +36,16 @@ object TealiumHelper {
             collectors.add(Collectors.Location)
             useRemoteLibrarySettings = true
             hostedDataLayerEventMappings = mapOf("pdp" to "product_id")
+
+            // Uncomment to enable Consent Management
+            // consentManagerEnabled = true
+            // and, uncomment one of the following lines to set the appropriate Consent Policy
+            // consentManagerPolicy = ConsentPolicy.GDPR
+            // consentManagerPolicy = ConsentPolicy.CCPA
+
         }
 
-        instance = Tealium("instance_1", config) {
-            consentManager.enabled = true
+        Tealium.create(BuildConfig.TEALIUM_INSTANCE, config) {
             visitorService?.delegate = object : VisitorServiceDelegate {
                 override fun didUpdate(visitorProfile: VisitorProfile) {
                     Logger.dev("--", "did update vp with $visitorProfile")
@@ -66,12 +71,12 @@ object TealiumHelper {
 
     fun trackView(name: String, data: Map<String, Any>?) {
         val viewDispatch = TealiumView(name, data)
-        instance.track(viewDispatch)
+        Tealium[BuildConfig.TEALIUM_INSTANCE]?.track(viewDispatch)
     }
 
     fun trackEvent(name: String, data: Map<String, Any>?) {
         val eventDispatch = TealiumEvent(name, data)
-        instance.track(eventDispatch)
+        Tealium[BuildConfig.TEALIUM_INSTANCE]?.track(eventDispatch)
     }
 
     val customValidator: DispatchValidator by lazy {

--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/MigrationTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/MigrationTests.kt
@@ -73,7 +73,7 @@ class MigrationTests {
     fun consent_status_consentedStatusIsMigrated() {
         consentPreferences.edit().putString("status", "consented").commit()
 
-        tealium = Tealium("instance_name", config)
+        tealium = Tealium.create("instance_name", config)
         assertEquals(ConsentStatus.CONSENTED, tealium.consentManager.userConsentStatus)
     }
 
@@ -81,7 +81,7 @@ class MigrationTests {
     fun consent_status_notConsentedStatusIsMigrated() {
         consentPreferences.edit().putString("status", "notConsented").commit()
 
-        tealium = Tealium("instance_name", config)
+        tealium = Tealium.create("instance_name", config)
         assertEquals(ConsentStatus.NOT_CONSENTED, tealium.consentManager.userConsentStatus)
     }
 
@@ -89,7 +89,7 @@ class MigrationTests {
     fun consent_status_unknownStatusIsMigrated() {
         consentPreferences.edit().putString("status", "unknown").commit()
 
-        tealium = Tealium("instance_name", config)
+        tealium = Tealium.create("instance_name", config)
         assertEquals(ConsentStatus.UNKNOWN, tealium.consentManager.userConsentStatus)
     }
 
@@ -97,7 +97,7 @@ class MigrationTests {
     fun consent_categories_categoryListIsMigrated() {
         consentPreferences.edit().putStringSet("categories", setOf("affiliates", "email", "cdp")).commit()
 
-        tealium = Tealium("instance_name", config)
+        tealium = Tealium.create("instance_name", config)
         val categories = tealium.consentManager.userConsentCategories!!
         assertNotNull(categories)
         assertEquals(3, categories.size)
@@ -110,7 +110,7 @@ class MigrationTests {
     fun consent_categories_nullCategoryListIsMigrated() {
         consentPreferences.edit().putStringSet("categories", null).commit()
 
-        tealium = Tealium("instance_name", config)
+        tealium = Tealium.create("instance_name", config)
         val categories = tealium.consentManager.userConsentCategories
         assertNull(categories)
     }
@@ -127,7 +127,7 @@ class MigrationTests {
             putStringSet("my_string_set", setOf("string_value_1", "string_value_2"))
         }.commit()
 
-        tealium = Tealium("instance_name", config)
+        tealium = Tealium.create("instance_name", config)
         assertTrue(tealium.dataLayer.contains("my_string"))
         assertTrue(tealium.dataLayer.contains("my_int"))
         assertTrue(tealium.dataLayer.contains("my_float"))


### PR DESCRIPTION
 - Tealium constructor privatised; construction switching to `Tealium.create(..)`
 - Test updates as a result of the privatised constructor
 - Sample app updates to reference the Tealium instances, and some sample code added to show how to enable consent management
 - Minor code formatting