### PR TITLE
dispatch map copy + rollback JsonLoader singleton

### DIFF
--- a/location/src/test/java/com/tealium/location/LocationGeofenceLoaderTests.kt
+++ b/location/src/test/java/com/tealium/location/LocationGeofenceLoaderTests.kt
@@ -114,7 +114,7 @@ class LocationGeofenceLoaderTests {
         val app = RuntimeEnvironment.application
         Assert.assertNotNull(app)
 
-        val assetLoader = JsonLoader.getInstance(app)
+        val assetLoader = JsonLoader(app)
         val jsonString = assetLoader.loadFromAsset("validGeofence.json")
 
         val geofenceLocationResult = GeofenceLocation.jsonArrayToGeofenceLocation(JSONArray(jsonString))
@@ -126,7 +126,7 @@ class LocationGeofenceLoaderTests {
         val app = RuntimeEnvironment.application
         Assert.assertNotNull(app)
 
-        val assetLoader = JsonLoader.getInstance(app)
+        val assetLoader = JsonLoader(app)
         val jsonString = assetLoader.loadFromAsset("invalidGeofence.json")
 
         val geofenceLocationResult = GeofenceLocation.jsonArrayToGeofenceLocation(JSONArray(jsonString))
@@ -138,7 +138,7 @@ class LocationGeofenceLoaderTests {
         val app = RuntimeEnvironment.application
         Assert.assertNotNull(app)
 
-        val assetLoader = JsonLoader.getInstance(app)
+        val assetLoader = JsonLoader(app)
         val jsonString = assetLoader.loadFromAsset("validAndInvalidGeofence.json")
 
         val geofenceObj1 = GeofenceLocation.create("Tealium_asset1", 59.4610304, -9.9707625, 100, -1, 0, true, true)

--- a/tealiumlibrary/src/main/java/com/tealium/core/JsonLoader.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/JsonLoader.kt
@@ -30,11 +30,11 @@ interface Loader {
     fun loadFromUrl(url: URL): Any?
 }
 
-class JsonLoader private constructor(val application: Application) : Loader {
+class JsonLoader(val application: Application) : Loader {
 
     override fun loadFromFile(file: File): String? {
         return if (file.exists()) {
-           file.readText(Charsets.UTF_8)
+            file.readText(Charsets.UTF_8)
         } else {
             Logger.dev(BuildConfig.TAG, "File not found (${file.name})")
             null
@@ -80,7 +80,8 @@ class JsonLoader private constructor(val application: Application) : Loader {
     }
 
     companion object {
-        @Volatile private var instance: JsonLoader? = null
+        @Volatile
+        private var instance: JsonLoader? = null
 
         fun getInstance(application: Application): JsonLoader = instance ?: synchronized(this) {
             instance ?: JsonLoader(application).also { instance = it }

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -158,10 +158,6 @@ class Tealium private constructor(val key: String, val config: TealiumConfig, pr
 
         val dispatchCopy = GenericDispatch(dispatch)
 
-        if (dispatchCopy.timestamp == null) {
-            dispatchCopy.timestamp = System.currentTimeMillis()
-        }
-
         when (initialized.get()) {
             true -> {
                 // needs to be done once we're fully initialised, else Session events might be missed

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -19,6 +19,7 @@ import com.tealium.core.validation.ConnectivityValidator
 import com.tealium.core.validation.DispatchValidator
 import com.tealium.dispatcher.Dispatch
 import com.tealium.dispatcher.Dispatcher
+import com.tealium.dispatcher.GenericDispatch
 import com.tealium.tealiumlibrary.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -155,8 +156,10 @@ class Tealium private constructor(val key: String, val config: TealiumConfig, pr
             return
         }
 
-        if (dispatch.timestamp == null) {
-            dispatch.timestamp = System.currentTimeMillis()
+        val dispatchCopy = GenericDispatch(dispatch)
+
+        if (dispatchCopy.timestamp == null) {
+            dispatchCopy.timestamp = System.currentTimeMillis()
         }
 
         when (initialized.get()) {
@@ -164,12 +167,12 @@ class Tealium private constructor(val key: String, val config: TealiumConfig, pr
                 // needs to be done once we're fully initialised, else Session events might be missed
                 // by any modules that listen. we should consider changing the implementation of [Dispatch]
                 // to keep track of the time it was created, so we can use that.
-                sessionManager.track(dispatch)
-                dispatchRouter.track(dispatch)
+                sessionManager.track(dispatchCopy)
+                dispatchRouter.track(dispatchCopy)
             }
             false -> {
                 logger.dev(BuildConfig.TAG, "Instance not yet initialized; buffering.")
-                dispatchBuffer.add(dispatch)
+                dispatchBuffer.add(dispatchCopy)
             }
         }
     }

--- a/tealiumlibrary/src/main/java/com/tealium/dispatcher/GenericDispatch.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/dispatcher/GenericDispatch.kt
@@ -1,0 +1,37 @@
+package com.tealium.dispatcher
+
+internal class GenericDispatch(dispatch: Dispatch) : Dispatch {
+
+    override val id: String = dispatch.id
+    override var timestamp: Long? = dispatch.timestamp
+
+    private val payload = shallowCopy(dispatch.payload())
+
+    override fun payload(): Map<String, Any> {
+        return payload.toMap()
+    }
+
+    override fun addAll(data: Map<String, Any>) {
+        payload.putAll(data)
+    }
+
+    companion object Utils {
+
+        /**
+         * Performs a shallow copy on the [map] parameter and returns a new [MutableMap] containing
+         * copies of the first level of data from the original [map]
+         */
+        fun shallowCopy(map: Map<String, Any>): MutableMap<String, Any> {
+            val newMap = map.toMutableMap()
+            newMap.forEach {
+                val value = it.value
+                when (value) {
+                    is Collection<*> -> newMap[it.key] = value.toMutableList()
+                    is Map<*, *> -> newMap[it.key] = value.toMutableMap()
+                    is Array<*> -> newMap[it.key] = value.copyOf()
+                }
+            }
+            return newMap
+        }
+    }
+}

--- a/tealiumlibrary/src/main/java/com/tealium/dispatcher/GenericDispatch.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/dispatcher/GenericDispatch.kt
@@ -3,7 +3,7 @@ package com.tealium.dispatcher
 internal class GenericDispatch(dispatch: Dispatch) : Dispatch {
 
     override val id: String = dispatch.id
-    override var timestamp: Long? = dispatch.timestamp
+    override var timestamp: Long? = dispatch.timestamp ?: System.currentTimeMillis()
 
     private val payload = shallowCopy(dispatch.payload())
 

--- a/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/GenericDispatchTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/GenericDispatchTests.kt
@@ -1,0 +1,122 @@
+package com.tealium.core.dispatcher
+
+import CoreConstant.TEALIUM_EVENT
+import com.tealium.dispatcher.GenericDispatch
+import com.tealium.dispatcher.TealiumEvent
+import com.tealium.dispatcher.TealiumView
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GenericDispatchTests {
+
+    private lateinit var view: TealiumView
+    private lateinit var event: TealiumEvent
+
+    private lateinit var genericView: GenericDispatch
+    private lateinit var genericEvent: GenericDispatch
+
+    @Before
+    fun setUp() {
+        view = TealiumView("view_name")
+        event = TealiumEvent("event_name")
+
+        genericView = GenericDispatch(view)
+        genericEvent = GenericDispatch(event)
+    }
+
+    @After
+    fun tearDown() {
+
+    }
+
+    @Test
+    fun create_IdAndTimestampAreEqualButNotSame() {
+        assertEquals(view.id, genericView.id)
+        assertEquals(event.id, genericEvent.id)
+        assertEquals(view.timestamp, genericView.timestamp)
+        assertEquals(event.timestamp, genericEvent.timestamp)
+
+        genericView.timestamp = 1L
+        genericEvent.timestamp = 1L
+        assertNotEquals(view.timestamp, genericView.timestamp)
+        assertNotEquals(event.timestamp, genericEvent.timestamp)
+        assertNotSame(view.timestamp, genericView.timestamp)
+        assertNotSame(event.timestamp, genericEvent.timestamp)
+    }
+
+    @Test
+    fun create_PayloadMapIsNotTheSame() {
+        assertNotSame(view.payload(), genericView.payload())
+        assertNotSame(event.payload(), genericEvent.payload())
+    }
+
+    @Test
+    fun create_PayloadUpdate_NewDataDoesNotAffectOriginal() {
+        view.addAll(mapOf("new_data_1" to "new_value_1"))
+        genericView.addAll(mapOf("new_data_2" to "new_value_2"))
+
+        assertTrue(view.payload().containsKey("new_data_1"))
+        assertFalse(genericView.payload().containsKey("new_data_1"))
+
+        assertFalse(view.payload().containsKey("new_data_2"))
+        assertTrue(genericView.payload().containsKey("new_data_2"))
+    }
+
+    @Test
+    fun create_PayloadUpdate_ExistingDataDoesNotAffectOriginal() {
+        view.addAll(mapOf(TEALIUM_EVENT to "new_value_1"))
+        assertTrue(view.payload()[TEALIUM_EVENT] == "new_value_1")
+        assertTrue(genericView.payload()[TEALIUM_EVENT] == "view_name")
+
+        genericView.addAll(mapOf(TEALIUM_EVENT to "new_value_2"))
+        assertTrue(view.payload()[TEALIUM_EVENT] == "new_value_1")
+        assertTrue(genericView.payload()[TEALIUM_EVENT] == "new_value_2")
+    }
+
+    @Test
+    fun create_PayloadUpdate_ReferenceObjectChangesDoNotAffectOriginal() {
+        val view = TealiumView("view_name", mapOf(
+                "map_data" to mutableMapOf("key" to "value"),
+                "list_data" to mutableListOf("string1", "string2"),
+                "array_data" to arrayOf("string1", "string2")
+        ))
+        val genericView = GenericDispatch(view)
+
+        (view.payload()["map_data"] as MutableMap<String, Any>)["key"] = "new value"
+        assertEquals("value", (genericView.payload()["map_data"] as Map<String, Any>)["key"])
+
+        (view.payload()["list_data"] as MutableList<String>)[0] = "new value"
+        assertEquals("string1", (genericView.payload()["list_data"] as MutableList<String>)[0])
+
+        (view.payload()["array_data"] as Array<String>)[0] = "new value"
+        assertEquals("string1", (genericView.payload()["array_data"] as Array<String>)[0])
+    }
+
+    @Test
+    fun create_PayloadUpdate_ReferenceObjectReplacementsDoNotAffectOriginal() {
+        val map = mutableMapOf("key" to "value")
+        val list = mutableListOf("string1", "string2")
+        val array = arrayOf("string1", "string2")
+
+        val view = TealiumView("view_name", mapOf(
+                "map_data" to map,
+                "list_data" to list,
+                "array_data" to array
+        ))
+        val genericView = GenericDispatch(view)
+
+        genericView.addAll(mapOf("map_data" to mapOf("new_key" to "new value")))
+        assertNotSame(genericView.payload()["map_data"], view.payload()["map_data"])
+
+        genericView.addAll(mapOf("list_data" to listOf("string3")))
+        assertNotSame(genericView.payload()["list_data"], view.payload()["list_data"])
+
+        genericView.addAll(mapOf("array_data" to arrayOf("string3")))
+        assertNotSame(genericView.payload()["array_data"], view.payload()["array_data"])
+    }
+}


### PR DESCRIPTION
 - Dispatch payload shallow copied when being sent through the system to minimize cross-instance editing.
 - rolled back the JsonLoader singleton use in tests as Robolectric fails 
   - could still privatise the constructor and move these tests to be an androidTest instead.