### PR TITLE
updates

### DIFF
--- a/remotecommanddispatcher/src/main/java/com/tealium/remotecommanddispatcher/RemoteCommandParser.kt
+++ b/remotecommanddispatcher/src/main/java/com/tealium/remotecommanddispatcher/RemoteCommandParser.kt
@@ -12,33 +12,31 @@ class RemoteCommandParser {
          */
         fun mapPayload(payload: Map<String, Any>, lookup: Map<String, String>): MutableMap<String, Any> {
             val mappedPayload = mutableMapOf<String, Any>()
-            lookup.forEach { (key, value) ->
-                payload[key]?.let { payloadValue ->
-                    lookup[key]?.let { lookupValue ->
-                        checkAndSplitDestinationList(lookupValue).forEach { valuesList ->
-                            val objectRow = splitKeys(valuesList, payloadValue, lookup)
-                            val objectKey = objectRow.second
-                            objectKey?.let {
-                                if (mappedPayload.containsKey(it)) {
-                                    // object key is already in the map, append to the same key
-                                    (mappedPayload[it] as? MutableMap<*, *>)?.let { objectMap ->
-                                        // create a map with a String key. This will throw an exception if the JSON mapping file does not use a String as a key.
-                                        val oMap = objectMap.entries.associate { entry -> entry.key as String to entry.value }.toMutableMap()
-                                        (objectRow.first[objectKey] as? Map<*, *>)?.let {
-                                            it.entries.associate { entry -> entry.key as String to entry.value } // as String }
-                                        }?.forEach { (kk, vv) ->
-                                            // add mapped values from splitKeys to the temporary oMap
-                                            oMap[kk] = vv
-                                            // append to the same key (e.g. "event")
-                                            mappedPayload[objectKey] = oMap
-                                        }
+            lookup.forEach { (lookupKey, lookupDestination) ->
+                payload[lookupKey]?.let { payloadValue ->
+                    checkAndSplitDestinationList(lookupDestination).forEach { destinations ->
+                        val objectRow = splitKeys(destinations, payloadValue)
+                        val objectKey = objectRow.second
+                        objectKey?.let {
+                            if (mappedPayload.containsKey(it)) {
+                                // object key is already in the map, append to the same key
+                                (mappedPayload[it] as? MutableMap<*, *>)?.let { objectMap ->
+                                    // create a map with a String key. This will throw an exception if the JSON mapping file does not use a String as a key.
+                                    val oMap = objectMap.entries.associate { entry -> entry.key.toString() to entry.value }.toMutableMap()
+                                    (objectRow.first[it] as? Map<*, *>)?.let {
+                                        it.entries.associate { entry -> entry.key.toString() to entry.value } // as String }
+                                    }?.forEach { (kk, vv) ->
+                                        // add mapped values from splitKeys to the temporary oMap
+                                        oMap[kk] = vv
+                                        // append to the same key (e.g. "event")
+                                        mappedPayload[it] = oMap
                                     }
-                                } else {
-                                    mappedPayload.putAll(objectRow.first)
                                 }
-                            } ?: run {
+                            } else {
                                 mappedPayload.putAll(objectRow.first)
                             }
+                        } ?: run {
+                            mappedPayload.putAll(objectRow.first)
                         }
                     }
                 }
@@ -51,22 +49,13 @@ class RemoteCommandParser {
          * Splits config mappings keys when a "." is present and creates nested object.
          * If key in JSON was "event.parameter", method returns  {event = {parameter = value}}
          */
-        private fun splitKeys(key: String, payloadValue: Any, lookup: Map<String, String>): Pair<MutableMap<String, Any>, String?> {
+        private fun splitKeys(key: String, payloadValue: Any): Pair<MutableMap<String, Any>, String?> {
             val result = mutableMapOf<String, Any>()
             var objectKey: String? = null
             if (key.contains(".")) {
                 val keyValue = key.split(".")
-                val temp = mutableMapOf<String, Any>()
-                if (payloadValue is Map<*, *>) {
-                    Logger.dev(BuildConfig.TAG, "payloadValue is a Map")
-                    (payloadValue as? Map<String, Any>)?.let {
-                        temp.putAll(mapPayload(it, lookup))
-                    }
-                } else {
-                    temp[keyValue[1]] = payloadValue
-                }
-                result[keyValue[0]] = temp
-                objectKey = keyValue[0]
+                result[keyValue.first()] = mutableMapOf(keyValue.last() to payloadValue)
+                objectKey = keyValue.first()
             } else {
                 result[key] = payloadValue
             }
@@ -80,11 +69,7 @@ class RemoteCommandParser {
          * method returns listOf("event.destination1", "event.destination2")
          */
         private fun checkAndSplitDestinationList(lookupValue: String): List<String> {
-            if (lookupValue.contains(",")) {
-                return lookupValue.split(",").map { it -> it.trim() }
-            }
-
-            return listOf(lookupValue)
+            return lookupValue.split(",").map { it.trim() }
         }
     }
 }

--- a/remotecommanddispatcher/src/main/java/com/tealium/remotecommanddispatcher/RemoteCommandParser.kt
+++ b/remotecommanddispatcher/src/main/java/com/tealium/remotecommanddispatcher/RemoteCommandParser.kt
@@ -1,7 +1,5 @@
 package com.tealium.remotecommanddispatcher
 
-import com.tealium.core.Logger
-
 class RemoteCommandParser {
     companion object {
 
@@ -16,20 +14,19 @@ class RemoteCommandParser {
                 payload[lookupKey]?.let { payloadValue ->
                     checkAndSplitDestinationList(lookupDestination).forEach { destinations ->
                         val objectRow = splitKeys(destinations, payloadValue)
-                        val objectKey = objectRow.second
-                        objectKey?.let {
-                            if (mappedPayload.containsKey(it)) {
+                        objectRow.second?.let { objectKey ->
+                            if (mappedPayload.containsKey(objectKey)) {
                                 // object key is already in the map, append to the same key
-                                (mappedPayload[it] as? MutableMap<*, *>)?.let { objectMap ->
+                                (mappedPayload[objectKey] as? MutableMap<*, *>)?.let { objectMap ->
                                     // create a map with a String key. This will throw an exception if the JSON mapping file does not use a String as a key.
                                     val oMap = objectMap.entries.associate { entry -> entry.key.toString() to entry.value }.toMutableMap()
-                                    (objectRow.first[it] as? Map<*, *>)?.let {
-                                        it.entries.associate { entry -> entry.key.toString() to entry.value } // as String }
+                                    (objectRow.first[objectKey] as? Map<*, *>)?.let {
+                                        it.entries.associate { entry -> entry.key.toString() to entry.value }
                                     }?.forEach { (kk, vv) ->
                                         // add mapped values from splitKeys to the temporary oMap
                                         oMap[kk] = vv
                                         // append to the same key (e.g. "event")
-                                        mappedPayload[it] = oMap
+                                        mappedPayload[objectKey] = oMap
                                     }
                                 }
                             } else {

--- a/remotecommanddispatcher/src/test/java/com/tealium/remotecommanddispatcher/RemoteCommandParserTests.kt
+++ b/remotecommanddispatcher/src/test/java/com/tealium/remotecommanddispatcher/RemoteCommandParserTests.kt
@@ -346,7 +346,7 @@ class RemoteCommandParserTest {
     @Test
     fun mapDispatchWithMultipleDotParamsWithSameNameSourceAndDestinations() {
         val dispatch = TealiumEvent(
-                "user_evenet",
+                "user_event",
                 mapOf("event_name" to "level_up",
                         "current_level" to 10,
                         "high_score" to 5000))


### PR DESCRIPTION
 - removed the re-mapping of payload sub-map keys, as there were issues with the returned map having duplicate key names in certain cases. I'm not sure of any use case where we would want to map keys within nested maps
 - some readability changes to the context variables