### PR TITLE
Collect/url overrides

### DIFF
--- a/collectdispatcher/build.gradle
+++ b/collectdispatcher/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
-version = '1.0.0'
+version = '1.0.1'
 
 android {
     compileSdkVersion 29
@@ -38,6 +38,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_android_version"
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:$mockk_version"
+    testImplementation "org.robolectric:robolectric:4.3.1"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_test_version"
     androidTestImplementation 'androidx.test:runner:1.2.0'
 }
 repositories {

--- a/collectdispatcher/src/main/java/com/tealium/collectdispatcher/CollectDispatcher.kt
+++ b/collectdispatcher/src/main/java/com/tealium/collectdispatcher/CollectDispatcher.kt
@@ -22,14 +22,12 @@ class CollectDispatcher(private val config: TealiumConfig,
         Dispatcher {
 
     val eventUrl: String
-        get() = config.overrideCollectUrl ?:
-            config.overrideCollectDomain?.let {
-                "https://$it/event"
-            } ?: COLLECT_URL
+        get() = config.overrideCollectUrl ?: config.overrideCollectDomain?.let {
+            "https://$it/event"
+        } ?: COLLECT_URL
 
     val batchEventUrl: String
-        get() = config.overrideCollectBatchUrl ?:
-        config.overrideCollectDomain?.let {
+        get() = config.overrideCollectBatchUrl ?: config.overrideCollectDomain?.let {
             "https://$it/bulk-event"
         } ?: BULK_URL
 

--- a/collectdispatcher/src/main/java/com/tealium/collectdispatcher/CollectDispatcher.kt
+++ b/collectdispatcher/src/main/java/com/tealium/collectdispatcher/CollectDispatcher.kt
@@ -21,13 +21,13 @@ class CollectDispatcher(private val config: TealiumConfig,
                         private val collectDispatchListener: CollectDispatcherListener? = null) :
         Dispatcher {
 
-    val urlString: String
+    val eventUrl: String
         get() = config.overrideCollectUrl ?:
             config.overrideCollectDomain?.let {
                 "https://$it/event"
             } ?: COLLECT_URL
 
-    val batchUrlString: String
+    val batchEventUrl: String
         get() = config.overrideCollectBatchUrl ?:
         config.overrideCollectDomain?.let {
             "https://$it/bulk-event"
@@ -55,7 +55,7 @@ class CollectDispatcher(private val config: TealiumConfig,
         var params = encoder.encode(dispatch)
         params += "&${encoder.encode(config)}"
         Logger.dev(BuildConfig.TAG, "Sending dispatch: ${dispatch.payload()}")
-        client.post(params, urlString, false)
+        client.post(params, eventUrl, false)
     }
 
     override suspend fun onBatchDispatchSend(dispatches: List<Dispatch>) {
@@ -63,7 +63,7 @@ class CollectDispatcher(private val config: TealiumConfig,
 
         val batchDispatch = BatchDispatch.create(dispatches)
         batchDispatch?.let {
-            client.post(JSONObject(batchDispatch.payload()).toString(), batchUrlString, true)
+            client.post(JSONObject(batchDispatch.payload()).toString(), batchEventUrl, true)
         }
     }
 

--- a/collectdispatcher/src/main/java/com/tealium/collectdispatcher/CollectDispatcher.kt
+++ b/collectdispatcher/src/main/java/com/tealium/collectdispatcher/CollectDispatcher.kt
@@ -21,11 +21,17 @@ class CollectDispatcher(private val config: TealiumConfig,
                         private val collectDispatchListener: CollectDispatcherListener? = null) :
         Dispatcher {
 
-    private val urlString: String
-        get() = config.overrideCollectUrl ?: COLLECT_URL
+    val urlString: String
+        get() = config.overrideCollectUrl ?:
+            config.overrideCollectDomain?.let {
+                "https://$it/event"
+            } ?: COLLECT_URL
 
-    private val batchUrlString: String
-        get() = config.overrideCollectUrl ?: BULK_URL
+    val batchUrlString: String
+        get() = config.overrideCollectBatchUrl ?:
+        config.overrideCollectDomain?.let {
+            "https://$it/bulk-event"
+        } ?: BULK_URL
 
     init {
         client.networkClientListener = object : NetworkClientListener {

--- a/collectdispatcher/src/main/java/com/tealium/collectdispatcher/TealiumConfigCollectDispatcher.kt
+++ b/collectdispatcher/src/main/java/com/tealium/collectdispatcher/TealiumConfigCollectDispatcher.kt
@@ -2,17 +2,47 @@ package com.tealium.collectdispatcher
 
 import com.tealium.core.TealiumConfig
 
+const val COLLECT_OVERRIDE_DOMAIN = "override_collect_domain"
 const val COLLECT_OVERRIDE_URL = "override_collect_url"
+const val COLLECT_OVERRIDE_BATCH_URL = "override_collect_batch_url"
 
 /**
- * Sets the URL to send event data to. Defaults are:
- * https://collect.tealiumiq.com/event for individual events, and
- * https://collect.tealiumiq.com/bulk-event for batches of multiple events.
+ * Sets the Domain to send event data to. Use this in preference to either [overrideCollectUrl] or
+ * [overrideCollectBatchUrl] to override only the domain portion of Tealium Collect endpoint.
+ *
+ * Default value is `collect.tealiumiq.com` and this will be used to build the full URL for both
+ * individual and batched events
+ */
+var TealiumConfig.overrideCollectDomain: String?
+    get() = options[COLLECT_OVERRIDE_DOMAIN] as? String
+    set(value) {
+        value?.let {
+            options[COLLECT_OVERRIDE_DOMAIN] = it
+        }
+    }
+
+/**
+ * Sets the URL to send individual event data to. Default is:
+ * https://collect.tealiumiq.com/event
+ *
+ * See [overrideCollectBatchUrl] if batching is enabled.
  */
 var TealiumConfig.overrideCollectUrl: String?
     get() = options[COLLECT_OVERRIDE_URL] as? String
     set(value) {
         value?.let {
             options[COLLECT_OVERRIDE_URL] = it
+        }
+    }
+
+/**
+ * Sets the Bulk URL to send event data to. Defaults is:
+ * https://collect.tealiumiq.com/bulk-event
+ */
+var TealiumConfig.overrideCollectBatchUrl: String?
+    get() = options[COLLECT_OVERRIDE_BATCH_URL] as? String
+    set(value) {
+        value?.let {
+            options[COLLECT_OVERRIDE_BATCH_URL] = it
         }
     }

--- a/collectdispatcher/src/main/java/com/tealium/collectdispatcher/TealiumConfigCollectDispatcher.kt
+++ b/collectdispatcher/src/main/java/com/tealium/collectdispatcher/TealiumConfigCollectDispatcher.kt
@@ -36,7 +36,7 @@ var TealiumConfig.overrideCollectUrl: String?
     }
 
 /**
- * Sets the Bulk URL to send event data to. Defaults is:
+ * Sets the Bulk URL to send event data to. Default is:
  * https://collect.tealiumiq.com/bulk-event
  */
 var TealiumConfig.overrideCollectBatchUrl: String?

--- a/collectdispatcher/src/test/java/com/tealium/collectdispatcher/CollectDispatcherTests.kt
+++ b/collectdispatcher/src/test/java/com/tealium/collectdispatcher/CollectDispatcherTests.kt
@@ -182,8 +182,8 @@ class CollectDispatcherTests {
                 client = networkClient,
                 collectDispatchListener = listener)
 
-        networkClient.networkClientListener?.onNetworkResponse(200,"")
-        networkClient.networkClientListener?.onNetworkResponse(404,"Not Found")
+        networkClient.networkClientListener?.onNetworkResponse(200, "")
+        networkClient.networkClientListener?.onNetworkResponse(404, "Not Found")
         networkClient.networkClientListener?.onNetworkError("My Error")
 
         verify {

--- a/collectdispatcher/src/test/java/com/tealium/collectdispatcher/CollectDispatcherTests.kt
+++ b/collectdispatcher/src/test/java/com/tealium/collectdispatcher/CollectDispatcherTests.kt
@@ -1,0 +1,194 @@
+package com.tealium.collectdispatcher
+
+import android.app.Application
+import com.tealium.core.*
+import com.tealium.core.messaging.AfterDispatchSendCallbacks
+import com.tealium.core.network.HttpClient
+import com.tealium.core.network.NetworkClient
+import com.tealium.dispatcher.BatchDispatch
+import com.tealium.dispatcher.TealiumEvent
+import io.mockk.MockKAnnotations
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class CollectDispatcherTests {
+
+    @MockK
+    lateinit var mockApplication: Application
+
+    @MockK
+    lateinit var mockContext: TealiumContext
+
+    @MockK
+    lateinit var mockConfig: TealiumConfig
+
+    @MockK
+    lateinit var mockEncoder: Encoder
+
+    @MockK
+    lateinit var mockNetworkClient: NetworkClient
+
+    @MockK
+    lateinit var mockAfterDispatchSendCallbacks: AfterDispatchSendCallbacks
+
+    @MockK
+    lateinit var mockFile: File
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        every { mockNetworkClient.networkClientListener = any() } just Runs
+        every { mockConfig.accountName } returns "test-account"
+        every { mockConfig.profileName } returns "test-profile"
+        every { mockConfig.environment } returns Environment.DEV
+        every { mockConfig.dataSourceId } returns "test-datasource"
+        every { mockConfig.application } returns mockApplication
+        every { mockApplication.filesDir } returns mockFile
+        every { mockContext.config } returns mockConfig
+
+        // no overrides byt default
+        every { mockConfig.overrideCollectDomain } returns null
+        every { mockConfig.overrideCollectUrl } returns null
+        every { mockConfig.overrideCollectBatchUrl } returns null
+    }
+
+    @Test
+    fun factory_DispatchersReferencesCompanion() {
+        assertSame(CollectDispatcher.Companion, Dispatchers.Collect)
+        assertTrue(Dispatchers.Collect is DispatcherFactory)
+    }
+
+    @Test
+    fun factory_createsNewInstances() {
+        val collect1 = CollectDispatcher.create(mockContext, mockAfterDispatchSendCallbacks)
+        val collect2 = CollectDispatcher.create(mockContext, mockAfterDispatchSendCallbacks)
+
+        assertNotNull(collect1)
+        assertNotNull(collect2)
+        assertNotSame(collect1, collect2)
+    }
+
+    @Test
+    fun config_OverridesAreSetCorrectly() {
+        val config = TealiumConfig(mockApplication,
+                mockConfig.accountName,
+                mockConfig.profileName,
+                mockConfig.environment,
+                dataSourceId = mockConfig.dataSourceId)
+
+        config.overrideCollectDomain = null
+        assertNull(config.overrideCollectDomain)
+        config.overrideCollectDomain = "my.override"
+        assertEquals("my.override", config.overrideCollectDomain)
+
+        config.overrideCollectUrl = null
+        assertNull(config.overrideCollectUrl)
+        config.overrideCollectUrl = "my.override"
+        assertEquals("my.override", config.overrideCollectUrl)
+
+        config.overrideCollectBatchUrl = null
+        assertNull(config.overrideCollectBatchUrl)
+        config.overrideCollectBatchUrl = "my.override"
+        assertEquals("my.override", config.overrideCollectBatchUrl)
+    }
+
+    @Test
+    fun urls_DefaultsAreUsedWhenNotOverridden() {
+        // no overrides set in [setUp]
+        val collectDispatcher = CollectDispatcher(mockConfig, mockEncoder, mockNetworkClient)
+
+        assertEquals(CollectDispatcher.COLLECT_URL, collectDispatcher.eventUrl)
+        assertEquals(CollectDispatcher.BULK_URL, collectDispatcher.batchEventUrl)
+    }
+
+    @Test
+    fun urls_DefaultDomainGetsOverridden() {
+        every { mockConfig.overrideCollectDomain } returns "cname.domain.com"
+        every { mockConfig.overrideCollectUrl } returns null
+        every { mockConfig.overrideCollectBatchUrl } returns null
+
+        val collectDispatcher = CollectDispatcher(mockConfig, mockEncoder, mockNetworkClient)
+
+        assertEquals("https://cname.domain.com/event", collectDispatcher.eventUrl)
+        assertEquals("https://cname.domain.com/bulk-event", collectDispatcher.batchEventUrl)
+    }
+
+    @Test
+    fun urls_DefaultUrlsAreOverridden() {
+        every { mockConfig.overrideCollectDomain } returns "cname.domain.com"
+        // URL Overrides should take precedence
+        every { mockConfig.overrideCollectUrl } returns "https://my.website.com/my-endpoint"
+        every { mockConfig.overrideCollectBatchUrl } returns "https://my.website.com/my-bulk-endpoint"
+
+        val collectDispatcher = CollectDispatcher(mockConfig, mockEncoder, mockNetworkClient)
+
+        assertEquals("https://my.website.com/my-endpoint", collectDispatcher.eventUrl)
+        assertEquals("https://my.website.com/my-bulk-endpoint", collectDispatcher.batchEventUrl)
+    }
+
+    @Test
+    fun events_IndividualEventsAreEncodedCorrectly() = runBlocking {
+        coEvery { mockNetworkClient.post(any(), any(), any()) } just Runs
+
+        val collectDispatcher = CollectDispatcher(mockConfig, client = mockNetworkClient)
+        val event = TealiumEvent("my-event", mapOf("key" to "value"))
+
+        collectDispatcher.onDispatchSend(event)
+
+        coVerify {
+            mockNetworkClient.post(
+                    "tealium_event_type=event&tealium_event=my-event&key=value&tealium_account=test-account&tealium_profile=test-profile",
+                    CollectDispatcher.COLLECT_URL,
+                    false
+            )
+        }
+    }
+
+    @Test
+    fun events_BatchEventsAreEncodedCorrectly() = runBlocking {
+        coEvery { mockNetworkClient.post(any(), any(), any()) } just Runs
+
+        val collectDispatcher = CollectDispatcher(mockConfig, client = mockNetworkClient)
+        val event = TealiumEvent("my-event", mapOf("key" to "value"))
+
+        collectDispatcher.onBatchDispatchSend(listOf(event, event))
+
+        coVerify {
+            mockNetworkClient.post(
+                    JSONObject(BatchDispatch.create(listOf(event, event))!!.payload()).toString(),
+                    CollectDispatcher.BULK_URL,
+                    true
+            )
+        }
+    }
+
+    @Test
+    fun listener_ReceivesHttpResponses() {
+        val listener = mockk<CollectDispatcherListener>()
+        every { listener.successfulTrack() } just Runs
+        every { listener.unsuccessfulTrack(any()) } just Runs
+
+        val networkClient = spyk(HttpClient(mockConfig))
+        val collectDispatcher = CollectDispatcher(mockConfig,
+                client = networkClient,
+                collectDispatchListener = listener)
+
+        networkClient.networkClientListener?.onNetworkResponse(200,"")
+        networkClient.networkClientListener?.onNetworkResponse(404,"Not Found")
+        networkClient.networkClientListener?.onNetworkError("My Error")
+
+        verify {
+            listener.successfulTrack()
+            listener.unsuccessfulTrack("Network error, response: Not Found")
+        }
+    }
+}


### PR DESCRIPTION
Config overrides added for better granularity
 - Url Overrides separated for both individual events and batched events
 - Domain Override added to support CNAMEs of the default Tealium Collect endpoints `/event` and `/bulk-event` 
Testing
 - Testing added for the new feature
 - Additional test coverage added