### PR TITLE
timed events pr-fixes

### DIFF
--- a/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
+++ b/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
@@ -6,6 +6,7 @@ import com.tealium.core.*
 import com.tealium.core.consent.ConsentPolicy
 import com.tealium.core.consent.consentManagerEnabled
 import com.tealium.core.consent.consentManagerPolicy
+import com.tealium.core.events.EventTrigger
 import com.tealium.core.validation.DispatchValidator
 import com.tealium.dispatcher.Dispatch
 import com.tealium.dispatcher.TealiumEvent
@@ -40,6 +41,9 @@ object TealiumHelper {
             // consentManagerPolicy = ConsentPolicy.GDPR
             // consentManagerPolicy = ConsentPolicy.CCPA
 
+            timedEventTriggers = listOf(
+                    EventTrigger.forEventName("start_event", "end_event")
+            )
         }
 
         Tealium.create(BuildConfig.TEALIUM_INSTANCE, config) {

--- a/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
+++ b/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
@@ -41,7 +41,7 @@ object TealiumHelper {
             // consentManagerPolicy = ConsentPolicy.GDPR
             // consentManagerPolicy = ConsentPolicy.CCPA
 
-            timedEventTriggers = listOf(
+            timedEventTriggers = mutableListOf(
                     EventTrigger.forEventName("start_event", "end_event")
             )
         }

--- a/tealiumlibrary/src/main/java/com/tealium/core/TealiumConfig.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/TealiumConfig.kt
@@ -89,7 +89,7 @@ class TealiumConfig @JvmOverloads constructor(val application: Application,
     /**
      * A list of EventTriggers for automatically starting and stopping TimedEvents.
      */
-    var timedEventTriggers: List<EventTrigger> = emptyList()
+    var timedEventTriggers: MutableList<EventTrigger> = mutableListOf()
 
     init {
         tealiumDirectory.mkdirs()

--- a/tealiumlibrary/src/main/java/com/tealium/core/events/EventTrigger.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/events/EventTrigger.kt
@@ -11,12 +11,6 @@ interface EventTrigger {
     val eventName: String
 
     /**
-     * Optional additional event data to add to the payload when the Trigger signals the event
-     * should stop timing.
-     */
-    val data: Map<String, Any>?
-
-    /**
      * Signals that the timer should begin for this named event.
      *
      * @return true if the timer should begin, otherwise false
@@ -38,12 +32,11 @@ interface EventTrigger {
          *
          * @param startEvent The event name that should trigger the Timed Event to be started
          * @param stopEvent The event name that should trigger the Timed Event to be stopped
-         * @param data Optional - context data that will be added to the Dispatch when the Timed Event is stopped
          * @param eventName Optional - override the timed_event_name value sent when the Timed Event is stopped.
          * Default is "$startName::$stopName"
          */
-        fun forEventName(startEvent: String, stopEvent: String, data: Map<String, Any>? = null, eventName: String? = null): EventTrigger {
-            return EventNameTrigger(startEvent, stopEvent, data, eventName)
+        fun forEventName(startEvent: String, stopEvent: String, eventName: String? = null): EventTrigger {
+            return EventNameTrigger(startEvent, stopEvent, eventName)
         }
     }
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/events/EventTrigger.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/events/EventTrigger.kt
@@ -31,8 +31,19 @@ interface EventTrigger {
     fun shouldStop(dispatch: Dispatch): Boolean
 
     companion object {
-        fun forEventName(eventName: String, startEvent: String, stopEvent: String, data: Map<String, Any>? = null): EventTrigger {
-            return EventNameTrigger(eventName, startEvent, stopEvent, data)
+
+        /**
+         * Creates an EventTrigger that uses the value of [TEALIUM_EVENT] from the [Dispatch] to
+         * start or stop a Timed Event.
+         *
+         * @param startEvent The event name that should trigger the Timed Event to be started
+         * @param stopEvent The event name that should trigger the Timed Event to be stopped
+         * @param data Optional - context data that will be added to the Dispatch when the Timed Event is stopped
+         * @param eventName Optional - override the timed_event_name value sent when the Timed Event is stopped.
+         * Default is "$startName::$stopName"
+         */
+        fun forEventName(startEvent: String, stopEvent: String, data: Map<String, Any>? = null, eventName: String? = null): EventTrigger {
+            return EventNameTrigger(startEvent, stopEvent, data, eventName)
         }
     }
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/events/TimedEvent.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/events/TimedEvent.kt
@@ -48,11 +48,14 @@ data class TimedEvent(
             return when (isValid(timedEvent)) {
                 false -> null
                 true -> {
+                    val stopTime = timedEvent.stopTime ?: return null
+                    val duration = timedEvent.duration ?: return null
+
                     mutableMapOf(
                             KEY_TIMED_EVENT_NAME to timedEvent.eventName,
                             KEY_TIMED_EVENT_START to timedEvent.startTime,
-                            KEY_TIMED_EVENT_END to timedEvent.stopTime!!,
-                            KEY_TIMED_EVENT_DURATION to timedEvent.duration!!
+                            KEY_TIMED_EVENT_END to stopTime,
+                            KEY_TIMED_EVENT_DURATION to duration
                     ).also {
                         if (timedEvent.data != null) it.putAll(timedEvent.data)
                     }

--- a/tealiumlibrary/src/main/java/com/tealium/core/events/TimedEventsManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/events/TimedEventsManager.kt
@@ -104,7 +104,7 @@ internal class TimedEventsManager(private val context: TealiumContext) : TimedEv
                     // timed event not started yet, so check if it should be started
                     if (trigger.shouldStart(dispatch)) {
                         startTimedEvent(trigger.eventName, dispatch.timestamp
-                                ?: timestamp, trigger.data)
+                                ?: timestamp, null)
                     }
                 }
             }

--- a/tealiumlibrary/src/main/java/com/tealium/core/events/triggers/EventNameTrigger.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/events/triggers/EventNameTrigger.kt
@@ -5,7 +5,6 @@ import com.tealium.dispatcher.Dispatch
 
 internal class EventNameTrigger(val startName: String,
                                 val stopName: String,
-                                override val data: Map<String, Any>? = null,
                                 eventName: String? = null) : EventTrigger {
 
     override val eventName: String = eventName ?: "$startName::$stopName"

--- a/tealiumlibrary/src/main/java/com/tealium/core/events/triggers/EventNameTrigger.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/events/triggers/EventNameTrigger.kt
@@ -3,10 +3,12 @@ package com.tealium.core.events.triggers
 import com.tealium.core.events.EventTrigger
 import com.tealium.dispatcher.Dispatch
 
-internal class EventNameTrigger(override val eventName: String,
-                                val startName: String,
+internal class EventNameTrigger(val startName: String,
                                 val stopName: String,
-                                override val data: Map<String, Any>? = null) : EventTrigger {
+                                override val data: Map<String, Any>? = null,
+                                eventName: String? = null) : EventTrigger {
+
+    override val eventName: String = eventName ?: "$startName::$stopName"
 
     override fun shouldStart(dispatch: Dispatch): Boolean {
         return dispatch[CoreConstant.TEALIUM_EVENT]?.let {

--- a/tealiumlibrary/src/test/java/com/tealium/core/events/TimedEventsManagerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/events/TimedEventsManagerTests.kt
@@ -136,17 +136,6 @@ class TimedEventsManagerTests {
     }
 
     @Test
-    fun addEventTrigger_AddsTrigger() {
-        val trigger: EventTrigger = mockk(relaxed = true)
-        every { trigger.eventName } returns "trigger_name"
-        timedEventsManager.addEventTrigger(trigger)
-
-        val foundTrigger = timedEventsManager.triggers.find { it.eventName == "trigger_name" }
-        assertNotNull(foundTrigger)
-        assertSame(trigger, foundTrigger)
-    }
-
-    @Test
     fun addEventTrigger_AddsMultiple() {
         val trigger1: EventTrigger = mockk(relaxed = true)
         every { trigger1.eventName } returns "trigger_name_1"

--- a/tealiumlibrary/src/test/java/com/tealium/core/events/TimedEventsManagerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/events/TimedEventsManagerTests.kt
@@ -38,8 +38,8 @@ class TimedEventsManagerTests {
 
     @Test
     fun config_TriggersGetAddedOnInit() {
-        val trigger1 = createMockTrigger("trigger_1", null, true, false)
-        val trigger2 = createMockTrigger("trigger_2", mapOf("extra" to "data"), false, true)
+        val trigger1 = createMockTrigger("trigger_1", true, false)
+        val trigger2 = createMockTrigger("trigger_2", false, true)
         every { mockConfig.timedEventTriggers } returns mutableListOf(trigger1, trigger2)
 
         timedEventsManager = TimedEventsManager(mockContext)
@@ -194,7 +194,7 @@ class TimedEventsManagerTests {
 
     @Test
     fun transform_ChecksTriggers_AndStartsTimedEvent() = runBlocking {
-        val startTrigger: EventTrigger = createMockTrigger("test_trigger", null, true, false)
+        val startTrigger: EventTrigger = createMockTrigger("test_trigger", true, false)
 
         assertNull(timedEventsManager.triggers.find { it.eventName == startTrigger.eventName })
         assertNull(timedEventsManager.timedEvents.find { it.eventName == startTrigger.eventName })
@@ -213,7 +213,7 @@ class TimedEventsManagerTests {
 
     @Test
     fun transform_StartTime_UsesDispatchTimestamp() = runBlocking {
-        val startTrigger: EventTrigger = createMockTrigger("test_trigger", null, true, false)
+        val startTrigger: EventTrigger = createMockTrigger("test_trigger", true, false)
         timedEventsManager.addEventTrigger(startTrigger)
 
         val dispatch: Dispatch = TealiumEvent("test").apply { timestamp = 1000L }
@@ -225,7 +225,7 @@ class TimedEventsManagerTests {
 
     @Test
     fun transform_StopTime_UsesDispatchTimestamp() = runBlocking {
-        val stopTrigger: EventTrigger = createMockTrigger("test_trigger", null, false, true)
+        val stopTrigger: EventTrigger = createMockTrigger("test_trigger", false, true)
         timedEventsManager.addEventTrigger(stopTrigger)
         val startTime = timedEventsManager.startTimedEvent(stopTrigger.eventName, null)!!
 
@@ -239,7 +239,7 @@ class TimedEventsManagerTests {
 
     @Test
     fun transform_ChecksTriggers_AndStopsTimedEvent() = runBlocking {
-        val stopTrigger: EventTrigger = createMockTrigger("test_trigger", null, false, true)
+        val stopTrigger: EventTrigger = createMockTrigger("test_trigger", false, true)
         timedEventsManager.addEventTrigger(stopTrigger)
         val startTime = timedEventsManager.startTimedEvent("test_trigger", null)!!
 
@@ -255,29 +255,12 @@ class TimedEventsManagerTests {
         assertEquals(event.duration, payload[TimedEvent.KEY_TIMED_EVENT_DURATION])
     }
 
-    @Test
-    fun transform_DataGetsAddedToDispatch() = runBlocking {
-        val trigger: EventTrigger = createMockTrigger("test_trigger", mapOf("extra" to "data"), true, false)
-        timedEventsManager.addEventTrigger(trigger)
-
-        val dispatch: Dispatch = TealiumEvent("test")
-        timedEventsManager.transform(dispatch) // start it via a trigger first.
-
-        // update trigger to stop instead of start
-        every { trigger.shouldStart(any()) } returns false
-        every { trigger.shouldStop(any()) } returns true
-        timedEventsManager.transform(dispatch) // stop via a trigger after
-
-        assertEquals("data", dispatch["extra"])
-    }
-
     /**
      * Utility for mocking Triggers.
      */
-    fun createMockTrigger(eventName: String, data: Map<String, Any>?, shouldStart: Boolean, shouldStop: Boolean): EventTrigger {
+    fun createMockTrigger(eventName: String, shouldStart: Boolean, shouldStop: Boolean): EventTrigger {
         val startTrigger: EventTrigger = mockk()
         every { startTrigger.eventName } returns eventName
-        every { startTrigger.data } returns data
         every { startTrigger.shouldStart(any()) } returns shouldStart
         every { startTrigger.shouldStop(any()) } returns shouldStop
         return startTrigger

--- a/tealiumlibrary/src/test/java/com/tealium/core/events/TimedEventsManagerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/events/TimedEventsManagerTests.kt
@@ -29,7 +29,7 @@ class TimedEventsManagerTests {
         MockKAnnotations.init(this)
         every { mockContext.config } returns mockConfig
         every { mockContext.track(any()) } just Runs
-        every { mockConfig.timedEventTriggers } returns emptyList()
+        every { mockConfig.timedEventTriggers } returns mutableListOf()
 
         Logger.logLevel = LogLevel.SILENT
 
@@ -40,7 +40,7 @@ class TimedEventsManagerTests {
     fun config_TriggersGetAddedOnInit() {
         val trigger1 = createMockTrigger("trigger_1", null, true, false)
         val trigger2 = createMockTrigger("trigger_2", mapOf("extra" to "data"), false, true)
-        every { mockConfig.timedEventTriggers } returns listOf(trigger1, trigger2)
+        every { mockConfig.timedEventTriggers } returns mutableListOf(trigger1, trigger2)
 
         timedEventsManager = TimedEventsManager(mockContext)
 

--- a/tealiumlibrary/src/test/java/com/tealium/core/events/triggers/EventTriggerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/events/triggers/EventTriggerTests.kt
@@ -13,7 +13,7 @@ class EventTriggerTests {
 
     @Before
     fun setUp() {
-        eventNameTrigger = EventNameTrigger("start", "stop", mapOf("extra" to "data"))
+        eventNameTrigger = EventNameTrigger("start", "stop")
     }
 
     @Test
@@ -21,7 +21,6 @@ class EventTriggerTests {
         assertEquals("start::stop", eventNameTrigger.eventName)
         assertEquals("start", eventNameTrigger.startName)
         assertEquals("stop", eventNameTrigger.stopName)
-        assertEquals(mapOf("extra" to "data"), eventNameTrigger.data)
     }
 
     @Test
@@ -97,11 +96,9 @@ class EventTriggerTests {
         val trigger1 = EventTrigger.forEventName("start", "stop", eventName = "my_event")
         assertNotNull(trigger1)
         assertEquals("my_event", trigger1.eventName)
-        assertNull(trigger1.data)
 
-        val trigger2 = EventTrigger.forEventName("start", "stop", mapOf("not" to "null"), "my_event")
+        val trigger2 = EventTrigger.forEventName("start", "stop", "my_event")
         assertNotNull(trigger2)
         assertEquals("my_event", trigger2.eventName)
-        assertNotNull(trigger2.data)
     }
 }

--- a/tealiumlibrary/src/test/java/com/tealium/core/events/triggers/EventTriggerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/events/triggers/EventTriggerTests.kt
@@ -10,14 +10,15 @@ import org.junit.Test
 class EventTriggerTests {
 
     private lateinit var eventNameTrigger: EventNameTrigger
+
     @Before
     fun setUp() {
-        eventNameTrigger = EventNameTrigger("triggered_event", "start", "stop", mapOf("extra" to "data"))
+        eventNameTrigger = EventNameTrigger("start", "stop", mapOf("extra" to "data"))
     }
 
     @Test
     fun eventNameTrigger_CheckInit() {
-        assertEquals("triggered_event", eventNameTrigger.eventName)
+        assertEquals("start::stop", eventNameTrigger.eventName)
         assertEquals("start", eventNameTrigger.startName)
         assertEquals("stop", eventNameTrigger.stopName)
         assertEquals(mapOf("extra" to "data"), eventNameTrigger.data)
@@ -37,7 +38,7 @@ class EventTriggerTests {
 
     @Test
     fun eventNameTrigger_ShouldNotStart_WhenNoTealiumEvent() {
-        val dispatch = object: Dispatch {
+        val dispatch = object : Dispatch {
             override val id: String
                 get() = ""
             override var timestamp: Long? = 1000L
@@ -71,7 +72,7 @@ class EventTriggerTests {
 
     @Test
     fun eventNameTrigger_ShouldNotStop_WhenNoTealiumEvent() {
-        val dispatch = object: Dispatch {
+        val dispatch = object : Dispatch {
             override val id: String
                 get() = ""
             override var timestamp: Long? = 1000L
@@ -93,12 +94,12 @@ class EventTriggerTests {
 
     @Test
     fun eventTrigger_CompanionShouldReturnTrigger() {
-        val trigger1 = EventTrigger.forEventName("my_event", "start", "stop")
+        val trigger1 = EventTrigger.forEventName("start", "stop", eventName = "my_event")
         assertNotNull(trigger1)
         assertEquals("my_event", trigger1.eventName)
         assertNull(trigger1.data)
 
-        val trigger2 = EventTrigger.forEventName("my_event", "start", "stop", mapOf("not" to "null"))
+        val trigger2 = EventTrigger.forEventName("start", "stop", mapOf("not" to "null"), "my_event")
         assertNotNull(trigger2)
         assertEquals("my_event", trigger2.eventName)
         assertNotNull(trigger2.data)


### PR DESCRIPTION
Pr changes as requested
 - some rework on the EventNameTrigger parameter order to make `eventName` optional, defaulting to `startName::stopName` per the spec.
 - basic example trigger setup in TealiumHelper
 - Unboxed vars in TimedEvent instead of not-null assertions.