### PR TITLE
Reset vid/updates

### DIFF
--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/TealiumTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/TealiumTests.kt
@@ -76,6 +76,22 @@ class TealiumTests {
     }
 
     @Test
+    fun testVisitorIdIsReset() {
+        val vid = tealium.visitorId
+        assertNotNull(vid)
+        assertEquals(32, tealium.visitorId.length)
+        assertEquals(tealium.visitorId, tealium.dataLayer.getString("tealium_visitor_id"))
+        val storedVid = tealium.dataLayer.getString("tealium_visitor_id")
+
+        val resetVid = tealium.resetVisitorId()
+        val storedResetVid = tealium.dataLayer.getString("tealium_visitor_id")
+        assertNotEquals(vid, resetVid)
+        assertNotEquals(storedVid, storedResetVid)
+        assertEquals(32, tealium.visitorId.length)
+        assertEquals(tealium.visitorId, tealium.dataLayer.getString("tealium_visitor_id"))
+    }
+
+    @Test
     fun testCallbackGetsExecuted() = runBlocking {
         var hasBeenCalled = false
 

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -310,6 +310,9 @@ class Tealium private constructor(val key: String, val config: TealiumConfig, pr
 
     /**
      * Removes current and regenerates a new visitor ID.
+     *
+     * [consentManager] Consent Status is unaffected by this method; consider whether you may need
+     * reset the consent status also.
      */
     fun resetVisitorId() {
         dataLayer.remove("tealium_visitor_id")

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -118,7 +118,7 @@ class Tealium private constructor(val key: String, val config: TealiumConfig, pr
      * Subsequent launches will take this key from the [dataLayer] so amending it there will affect
      * attribution of events.
      */
-    val visitorId: String
+    lateinit var visitorId: String
 
     /**
      * Provides access for users to manage their consent preferences.
@@ -308,6 +308,14 @@ class Tealium private constructor(val key: String, val config: TealiumConfig, pr
                 }
             }
         }
+    }
+
+    /**
+     * Removes current and regenerates a new visitor ID.
+     */
+    fun resetVisitorId() {
+        dataLayer.remove("tealium_visitor_id")
+        visitorId = getOrCreateVisitorId()
     }
 
     /**

--- a/tealiumlibrary/src/main/java/com/tealium/core/TealiumContext.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/TealiumContext.kt
@@ -11,12 +11,15 @@ import com.tealium.test.OpenForTesting
  */
 @OpenForTesting
 data class TealiumContext(val config: TealiumConfig,
-                          val visitorId: String,
+                          private val _visitorId: String,
                           val log: Logging,
                           val dataLayer: DataLayer,
                           val httpClient: NetworkClient,
                           val events: MessengerService,
                           val tealium: Tealium) {
+
+    val visitorId: String
+        get() = tealium.visitorId
 
     /**
      * Can be used by modules outside of the core to send tracking requests on this Tealium instance.

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
@@ -6,7 +6,6 @@ import com.tealium.core.messaging.EventRouter
 import com.tealium.core.messaging.LibrarySettingsUpdatedListener
 import com.tealium.core.settings.LibrarySettings
 import com.tealium.core.network.ConnectivityRetriever
-import com.tealium.core.network.HttpClient
 import com.tealium.core.network.NetworkClient
 import com.tealium.core.validation.DispatchValidator
 import com.tealium.dispatcher.Dispatch
@@ -15,22 +14,21 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
-class ConsentManager(private val config: TealiumConfig,
+class ConsentManager(private val context: TealiumContext,
                      private val eventRouter: EventRouter,
-                     private val visitorId: String,
                      private var librarySettings: LibrarySettings,
-                     val policy: ConsentPolicy? = config.consentManagerPolicy
+                     val policy: ConsentPolicy? = context.config.consentManagerPolicy
 ) : Collector, DispatchValidator, LibrarySettingsUpdatedListener {
 
     override val name: String = MODULE_NAME
-    override var enabled: Boolean = config.consentManagerEnabled ?: false
+    override var enabled: Boolean = context.config.consentManagerEnabled ?: false
 
-    private val consentLoggingUrl = config.consentManagerLoggingUrl
+    private val consentLoggingUrl = context.config.consentManagerLoggingUrl
             ?: "https://collect.tealiumiq.com/event"
-    private val connectivity = ConnectivityRetriever.getInstance(config.application)
-    private val consentSharedPreferences = ConsentSharedPreferences(config)
+    private val connectivity = ConnectivityRetriever.getInstance(context.config.application)
+    private val consentSharedPreferences = ConsentSharedPreferences(context.config)
     private val consentManagementPolicy: ConsentManagementPolicy?
-    private val httpClient: NetworkClient by lazy { HttpClient(config, connectivity) }
+    private val httpClient: NetworkClient = context.httpClient
 
     init {
         consentManagementPolicy = policy?.create(UserConsentPreferences(userConsentStatus, userConsentCategories))
@@ -73,7 +71,7 @@ class ConsentManager(private val config: TealiumConfig,
     /**
      * Sets whether Consent should be logged.
      */
-    var isConsentLoggingEnabled = config.consentManagerLoggingEnabled ?: false
+    var isConsentLoggingEnabled = context.config.consentManagerLoggingEnabled ?: false
 
     /**
      * Sends an HTTP request with the current policy status information to the configured endpoint.
@@ -81,7 +79,7 @@ class ConsentManager(private val config: TealiumConfig,
     private fun logConsentUpdate() {
         consentManagementPolicy?.let { policy ->
             if (policy.consentLoggingEnabled) {
-                if ((connectivity.isConnected() && librarySettings.wifiOnly) || connectivity.isConnectedWifi()) {
+                if ((connectivity.isConnected() && !librarySettings.wifiOnly) || connectivity.isConnectedWifi()) {
                     // TODO: consider implementing a general network queue
                     CoroutineScope(IO).launch {
                         val json = JSONObject()
@@ -90,9 +88,9 @@ class ConsentManager(private val config: TealiumConfig,
                         }
                         json.put(CoreConstant.TEALIUM_EVENT, policy.consentLoggingEventName)
 
-                        json.put(TEALIUM_ACCOUNT, config.accountName)
-                        json.put(TEALIUM_PROFILE, config.profileName)
-                        json.put(TEALIUM_VISITOR_ID, visitorId)
+                        json.put(TEALIUM_ACCOUNT, context.config.accountName)
+                        json.put(TEALIUM_PROFILE, context.config.profileName)
+                        json.put(TEALIUM_VISITOR_ID, context.visitorId)
 
                         httpClient.post(json.toString(), consentLoggingUrl, false)
                     }

--- a/visitorservice/src/androidTest/java/com/tealium/visitorservice/VisitorServiceInstrumentedTest.kt
+++ b/visitorservice/src/androidTest/java/com/tealium/visitorservice/VisitorServiceInstrumentedTest.kt
@@ -7,6 +7,7 @@ import com.tealium.core.messaging.EventRouter
 import com.tealium.core.messaging.MessengerService
 import com.tealium.core.network.HttpClient
 import io.mockk.*
+import io.mockk.impl.annotations.RelaxedMockK
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -18,6 +19,12 @@ import org.junit.Test
 
 class VisitorServiceInstrumentedTest {
 
+    @RelaxedMockK
+    lateinit var mockTealium: Tealium
+
+    @RelaxedMockK
+    lateinit var mockEventRouter: EventRouter
+
     lateinit var tealiumContext: TealiumContext
     val application = ApplicationProvider.getApplicationContext<Application>()
 
@@ -25,10 +32,8 @@ class VisitorServiceInstrumentedTest {
     fun setUp() {
         MockKAnnotations.init(this)
         val config = TealiumConfig(application, "account", "profile", Environment.DEV)
-        val mockEventRouter: EventRouter = mockk()
-        every { mockEventRouter.subscribe(any()) } just Runs
         val messengerService = MessengerService(mockEventRouter, CoroutineScope(Dispatchers.IO))
-        tealiumContext = TealiumContext(config, "visitor-1", Logger, mockk(), HttpClient(config), messengerService, mockk())
+        tealiumContext = TealiumContext(config, "visitor-1", Logger, mockk(), HttpClient(config), messengerService, mockTealium)
     }
 
     @Test

--- a/visitorservice/src/main/java/com/tealium/visitorservice/VisitorProfileManager.kt
+++ b/visitorservice/src/main/java/com/tealium/visitorservice/VisitorProfileManager.kt
@@ -1,10 +1,7 @@
 package com.tealium.visitorservice
 
 import com.tealium.core.*
-import com.tealium.core.messaging.BatchDispatchSendListener
-import com.tealium.core.messaging.DispatchSendListener
-import com.tealium.core.messaging.ExternalListener
-import com.tealium.core.messaging.Messenger
+import com.tealium.core.messaging.*
 import com.tealium.core.network.ResourceRetriever
 import com.tealium.dispatcher.Dispatch
 import kotlinx.coroutines.delay
@@ -30,14 +27,22 @@ class VisitorProfileManager(private val context: TealiumContext,
                                             ?: DEFAULT_REFRESH_INTERVAL,
                             private val visitorServiceUrl: String =
                                     context.config.overrideVisitorServiceUrl
-                                            ?: "https://visitor-service.tealiumiq.com/${context.config.accountName}/${context.config.profileName}/${context.visitorId}",
+                                            ?: DEFAULT_VISITOR_SERVICE_TEMPLATE,
                             private val loader: Loader = JsonLoader(context.config.application)) : DispatchSendListener, BatchDispatchSendListener {
 
     private val file = File(context.config.tealiumDirectory, VISITOR_PROFILE_FILENAME)
 
     val isUpdating = AtomicBoolean(false)
     private var lastUpdate: Long = -1L
-    private val resourceRetriever: ResourceRetriever
+    private var visitorId = context.visitorId
+        set(value) {
+            if (field != value) {
+                field = value
+                // URL needs updating
+                resourceRetriever = createResourceRetriever()
+            }
+        }
+    private var resourceRetriever: ResourceRetriever = createResourceRetriever()
 
     var visitorProfile: VisitorProfile = loadCachedProfile() ?: VisitorProfile()
         private set(value) {
@@ -45,12 +50,18 @@ class VisitorProfileManager(private val context: TealiumContext,
             context.events.send(VisitorUpdatedMessenger(value))
         }
 
-    init {
-        resourceRetriever = ResourceRetriever(context.config, visitorServiceUrl, context.httpClient).apply {
+    private fun createResourceRetriever(): ResourceRetriever {
+        return ResourceRetriever(context.config, generateVisitorServiceUrl(), context.httpClient).apply {
             useIfModifed = false
             maxRetries = 1
             refreshInterval = 0
         }
+    }
+
+    internal fun generateVisitorServiceUrl(): String {
+        return visitorServiceUrl.replace(PLACEHOLDER_ACCOUNT, context.config.accountName)
+                .replace(PLACEHOLDER_PROFILE, context.config.profileName)
+                .replace(PLACEHOLDER_VISITOR_ID, visitorId)
     }
 
     fun loadCachedProfile(): VisitorProfile? {
@@ -88,6 +99,9 @@ class VisitorProfileManager(private val context: TealiumContext,
     suspend fun requestVisitorProfile() {
         // no need if it's already being updated, but we won't adhere to the refreshInterval here.
         if (isUpdating.compareAndSet(false, true)) {
+            // Check for any updates to visitorId.
+            visitorId = context.visitorId
+
             for (i in 1..5) {
                 Logger.dev(BuildConfig.TAG, "Fetching visitor profile for ${context.visitorId}.")
 
@@ -124,5 +138,12 @@ class VisitorProfileManager(private val context: TealiumContext,
     companion object {
         const val VISITOR_PROFILE_FILENAME = "visitor_profile.json"
         const val DEFAULT_REFRESH_INTERVAL = 300L
+
+        // url replacememts
+        const val PLACEHOLDER_ACCOUNT = "{{account}}"
+        const val PLACEHOLDER_PROFILE = "{{profile}}"
+        const val PLACEHOLDER_VISITOR_ID = "{{visitorId}}"
+
+        const val DEFAULT_VISITOR_SERVICE_TEMPLATE = "https://visitor-service.tealiumiq.com/$PLACEHOLDER_ACCOUNT/$PLACEHOLDER_PROFILE/$PLACEHOLDER_VISITOR_ID"
     }
 }


### PR DESCRIPTION
 - amendments to the `TealiumContext` to return `Tealium.visitorId` from `getVisitorId()` which is always up to date.
 - ConsentManager and VisitorProfileManager also updated to support this change in visitor id.
 - bug fix in consent logging.