### PR TITLE
Dev/media fixes

### DIFF
--- a/media/src/main/java/com/tealium/media/Media.kt
+++ b/media/src/main/java/com/tealium/media/Media.kt
@@ -228,7 +228,7 @@ class Media(private val context: TealiumContext,
         }
 
         fun timeMillisToSeconds(time: Long): Double {
-            return (time / 1000).toDouble()
+            return time.toDouble() / 1000
         }
     }
 }

--- a/media/src/main/java/com/tealium/media/MediaSummary.kt
+++ b/media/src/main/java/com/tealium/media/MediaSummary.kt
@@ -77,7 +77,7 @@ data class MediaSummary(var sessionStartTime: Long = System.currentTimeMillis())
                 data[SummaryKey.TOTAL_SEEK_TIME] = it
             }
 
-            mediaSummary.sessionEndTime?.let {
+            mediaSummary.sessionEndTimestamp?.let {
                 data[SummaryKey.SESSION_END_TIME] = it
             }
             return data

--- a/media/src/main/java/com/tealium/media/sessions/HeartBeatMilestoneSession.kt
+++ b/media/src/main/java/com/tealium/media/sessions/HeartBeatMilestoneSession.kt
@@ -16,7 +16,7 @@ class HeartbeatMilestoneSession(private val mediaContent: MediaContent,
     private var heartbeatCount = 0
 
     override fun ping() {
-        if (totalContentPlayed.div(interval) > heartbeatCount) {
+        if (totalContentPlayed.times(1000).div(interval) > heartbeatCount) {
             heartbeatCount++
             mediaDispatcher.track(MediaEvent.HEARTBEAT, mediaContent)
         }

--- a/media/src/main/java/com/tealium/media/sessions/MilestoneSession.kt
+++ b/media/src/main/java/com/tealium/media/sessions/MilestoneSession.kt
@@ -18,7 +18,7 @@ open class MilestoneSession(private val mediaContent: MediaContent,
         get() {
             return lastPlayTimestamp?.let {
                 val timeElapsed = Media.timeMillisToSeconds(System.currentTimeMillis() - it)
-                totalPlaybackTime += timeElapsed
+                totalPlaybackTime = timeElapsed
                 totalPlaybackTime
             } ?: totalPlaybackTime
         }

--- a/media/src/main/java/com/tealium/media/sessions/SummarySession.kt
+++ b/media/src/main/java/com/tealium/media/sessions/SummarySession.kt
@@ -174,7 +174,6 @@ class SummarySession(private val mediaContent: MediaContent,
 
     private fun percentage(count: Int, total: Int): Double {
         return ((count.toDouble() / total.toDouble()) * 100)
-
     }
 
     companion object {

--- a/media/src/test/java/com/tealium/media/MediaTests.kt
+++ b/media/src/test/java/com/tealium/media/MediaTests.kt
@@ -18,6 +18,7 @@ import io.mockk.impl.annotations.RelaxedMockK
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -859,6 +860,10 @@ class MediaTests {
         }
     }
 
+    @Test
+    fun timeMillis() {
+        assertEquals(10.555, Media.timeMillisToSeconds(10555), 0.0)
+    }
 }
 
 private class TestActivity : Activity()

--- a/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
+++ b/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
@@ -37,8 +37,12 @@ object TealiumHelper {
                 Environment.DEV,
                 modules = mutableSetOf(
                         Modules.Lifecycle,
+                        Modules.VisitorService,
+                        Modules.HostedDataLayer,
+                        Modules.CrashReporter,
+                        Modules.AdIdentifier,
                         Modules.Media),
-                dispatchers = mutableSetOf(Dispatchers.Collect, Dispatchers.RemoteCommands)
+                dispatchers = mutableSetOf(Dispatchers.Collect, Dispatchers.TagManagement, Dispatchers.RemoteCommands)
         ).apply {
             useRemoteLibrarySettings = true
             hostedDataLayerEventMappings = mapOf("pdp" to "product_id")
@@ -47,7 +51,7 @@ object TealiumHelper {
             // and enable the consent manager
             consentManagerPolicy = ConsentPolicy.GDPR
             // consentManagerPolicy = ConsentPolicy.CCPA
-            consentExpiry = ConsentExpiry(1, TimeUnit.DAYS)
+            consentExpiry = ConsentExpiry(1, TimeUnit.MINUTES)
 
             timedEventTriggers = mutableListOf(
                     EventTrigger.forEventName("start_event", "end_event")

--- a/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
+++ b/mobile/src/main/java/com/tealium/mobile/TealiumHelper.kt
@@ -37,12 +37,8 @@ object TealiumHelper {
                 Environment.DEV,
                 modules = mutableSetOf(
                         Modules.Lifecycle,
-                        Modules.VisitorService,
-                        Modules.HostedDataLayer,
-                        Modules.CrashReporter,
-                        Modules.AdIdentifier,
                         Modules.Media),
-                dispatchers = mutableSetOf(Dispatchers.Collect, Dispatchers.TagManagement, Dispatchers.RemoteCommands)
+                dispatchers = mutableSetOf(Dispatchers.Collect, Dispatchers.RemoteCommands)
         ).apply {
             useRemoteLibrarySettings = true
             hostedDataLayerEventMappings = mapOf("pdp" to "product_id")
@@ -51,7 +47,7 @@ object TealiumHelper {
             // and enable the consent manager
             consentManagerPolicy = ConsentPolicy.GDPR
             // consentManagerPolicy = ConsentPolicy.CCPA
-            consentExpiry = ConsentExpiry(1, TimeUnit.MINUTES)
+            consentExpiry = ConsentExpiry(1, TimeUnit.DAYS)
 
             timedEventTriggers = mutableListOf(
                     EventTrigger.forEventName("start_event", "end_event")


### PR DESCRIPTION
fixes to a few issues I've found during review.
 - heartbeats stopped working after the first one as comparison was between `seconds` and `ms`
 - `Media.timeMillisToSeconds` converts to double first, else we lose the accuracy after the decimal point
 - switch to sending `sessionEndTimestamp` (String) instead of the Long, as per the spec and in keeping with `sessionStartTimestamp` 
 - `lastPlayTimestamp` was accumulating all time elapsed times, giving an incorrect value for hearbeats. 