### PR TITLE
batch compression fix

### DIFF
--- a/tealiumlibrary/src/main/java/com/tealium/dispatcher/BatchDispatch.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/dispatcher/BatchDispatch.kt
@@ -30,6 +30,7 @@ class BatchDispatch private constructor(dispatchList: List<Dispatch>) {
                     event[key]?.let {
                         shared[key] = it
                         keyFound = true
+                        event.remove(key)
                     }
                 } else {
                     event.remove(key)

--- a/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/BatchDispatchTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/BatchDispatchTests.kt
@@ -34,6 +34,10 @@ class BatchDispatchTests {
                 assertEquals("shared_value_2", e["shared_key_2"])
                 assertEquals("unique_value_$index", e["shared_key"])
                 assertEquals("unique_value_$index", e["unique_key_$index"])
+
+                assertNull(e[TEALIUM_ACCOUNT])
+                assertNull(e[TEALIUM_PROFILE])
+                assertNull(e[TEALIUM_ENVIRONMENT])
             }
         } ?: Assert.fail()
     }
@@ -64,7 +68,6 @@ class BatchDispatchTests {
             data[TEALIUM_ACCOUNT] = "account"
             data[TEALIUM_PROFILE] = "profile"
             data[TEALIUM_ENVIRONMENT] = "dev"
-
 
             // shared keys
             data["shared_key_1"] = "shared_value_1"


### PR DESCRIPTION
 - Batch compression fix - removes shared data from the the first event during compression. 