### PR TITLE
enable/disable remote_api

### DIFF
--- a/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/TagManagementDispatcher.kt
+++ b/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/TagManagementDispatcher.kt
@@ -41,10 +41,14 @@ class TagManagementDispatcher(private val context: TealiumContext,
                 "&${CoreConstant.LIBRARY_VERSION}=${BuildConfig.VERSION_NAME}" +
                 "&sdk_session_count=true"
 
+    private val remoteApiEnabled: Boolean = context.config.remoteApiEnabled ?: true
+
     private val scope = CoroutineScope(Dispatchers.Main)
     internal var webViewLoader = WebViewLoader(context, urlString, afterDispatchSendCallbacks, connectivityRetriever = connectivity)
 
     fun callRemoteCommandTags(dispatch: Dispatch) {
+        if (!remoteApiEnabled) return
+
         val remoteCommandScript = "utag.track(\"remote_api\", ${dispatch.toJsonString()})"
         onEvaluateJavascript(remoteCommandScript)
     }

--- a/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/TealiumConfigTagManagementDispatcher.kt
+++ b/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/TealiumConfigTagManagementDispatcher.kt
@@ -3,6 +3,7 @@ package com.tealium.tagmanagementdispatcher
 import com.tealium.core.TealiumConfig
 
 const val TAG_MANAGEMENT_OVERRIDE_URL = "override_tag_management_url"
+const val TAG_MANAGEMENT_REMOTE_API_ENABLED = "tag_management_remote_api_enabled"
 
 /**
  * Sets the URL to use for the Tag Management module.
@@ -13,5 +14,18 @@ var TealiumConfig.overrideTagManagementUrl: String?
     set(value) {
         value?.let {
             options[TAG_MANAGEMENT_OVERRIDE_URL] = it
+        }
+    }
+
+/**
+ * Enables/Disables `remote_api` events from being sent to the Tealium WebView
+ *
+ * A value of `false` will stop TagManagement based RemoteCommands from functioning correctly.
+ */
+var TealiumConfig.remoteApiEnabled: Boolean?
+    get() = options[TAG_MANAGEMENT_REMOTE_API_ENABLED] as? Boolean
+    set(value) {
+        value?.let {
+            options[TAG_MANAGEMENT_REMOTE_API_ENABLED] = it
         }
     }

--- a/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
+++ b/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
@@ -121,6 +121,9 @@ class WebViewLoader(private val context: TealiumContext,
                 if (isFavicon(it)) {
                     return
                 }
+                if (isAboutScheme(it)) {
+                    return
+                }
             }
 
             super.onReceivedError(view, errorCode, description, failingUrl)
@@ -317,6 +320,10 @@ class WebViewLoader(private val context: TealiumContext,
 
         private fun isFavicon(url: String): Boolean {
             return url.toLowerCase(Locale.ROOT).contains("favicon.ico")
+        }
+
+        private fun isAboutScheme(url: String): Boolean {
+            return url.toLowerCase(Locale.ROOT).startsWith("about:")
         }
 
         fun createSessionUrl(config: TealiumConfig, sessionId: Long): String {

--- a/tagmanagementdispatcher/src/test/java/com/tealium/tagmanagementdispatcher/TagManagementDispatcherTest.kt
+++ b/tagmanagementdispatcher/src/test/java/com/tealium/tagmanagementdispatcher/TagManagementDispatcherTest.kt
@@ -194,4 +194,38 @@ class TagManagementDispatcherTest {
 
         coVerify(exactly = 0) { mockWebViewLoader.loadUrlToWebView() }
     }
+
+    @Test
+    fun callRemoteCommandTags_DoesCall_WhenRemoteApiEnabled() {
+        config.remoteApiEnabled = true
+        val tagManagementDispatcher = TagManagementDispatcher(mockTealiumContext, mockDispatchSendCallbacks, mockConnectivity)
+        val mockWebView: WebView = mockk()
+        every { mockWebViewLoader.webView } returns mockWebView
+        tagManagementDispatcher.webViewLoader = mockWebViewLoader
+        every { mockWebViewLoader.webViewStatus.get() } returns PageStatus.LOADED_SUCCESS
+        every { mockWebViewLoader.loadUrlToWebView() } just Runs
+
+        tagManagementDispatcher.callRemoteCommandTags(TealiumEvent("test"))
+
+        verify(exactly = 1) {
+            mockWebView.evaluateJavascript(any(), any())
+        }
+    }
+
+    @Test
+    fun callRemoteCommandTags_DoesNotCall_WhenRemoteApiDisabled() {
+        config.remoteApiEnabled = false
+        val tagManagementDispatcher = TagManagementDispatcher(mockTealiumContext, mockDispatchSendCallbacks, mockConnectivity)
+        val mockWebView: WebView = mockk()
+        every { mockWebViewLoader.webView } returns mockWebView
+        tagManagementDispatcher.webViewLoader = mockWebViewLoader
+        every { mockWebViewLoader.webViewStatus.get() } returns PageStatus.LOADED_SUCCESS
+        every { mockWebViewLoader.loadUrlToWebView() } just Runs
+
+        tagManagementDispatcher.callRemoteCommandTags(TealiumEvent("test"))
+
+        verify(exactly = 0) {
+            mockWebView.evaluateJavascript(any(), any())
+        }
+    }
 }


### PR DESCRIPTION
 - `remoteApiEnabled` config option added to `TealiumConfig` to support disabling potentially unwanted `remote_api` events from being sent to the TagManagement WebView.
 - `about:` scheme added to the non-error conditions for the WebView since this can cause the chrome debugger to fail. 