### PR TITLE
content-type fixes

### DIFF
--- a/remotecommanddispatcher/src/test/java/com/tealium/remotecommanddispatcher/FormatterTests.kt
+++ b/remotecommanddispatcher/src/test/java/com/tealium/remotecommanddispatcher/FormatterTests.kt
@@ -1,0 +1,97 @@
+package com.tealium.remotecommanddispatcher
+
+import com.tealium.remotecommanddispatcher.remotecommands.HttpRemoteCommand.Formatter
+import com.tealium.remotecommanddispatcher.remotecommands.HttpRemoteCommand
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.nio.charset.Charset
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [21, 28])
+class FormatterTests {
+
+    val utf8: Charset = Charset.forName("utf-8")
+    val testJsonObject: JSONObject = JSONObject(mapOf(
+            "string" to "value",
+            "int" to 10,
+            "double" to 10.5,
+            "boolean" to true,
+            "map" to mapOf("key" to "value"),
+            "list" to listOf("value_1", "value_2"),
+            "array" to arrayOf("value_1", "value_2")))
+    val testString: String = "my_payload"
+    val testObject: Any = object : Any() {
+        override fun toString(): String {
+            return testString
+        }
+    }
+
+    @Test
+    fun formatters_Default_FormatsJson() {
+        val formatter: Formatter = HttpRemoteCommand.Formatters.formatterFor("application/json")
+        val formatted = formatter.format(testJsonObject, utf8)!!
+
+        val jsonString = formatted.toString(utf8)
+        assertTrue(jsonString.startsWith("{"))
+        assertTrue(jsonString.endsWith("}"))
+        assertTrue(jsonString.contains("\"string\":\"value\""))
+        assertTrue(jsonString.contains("\"int\":10"))
+        assertTrue(jsonString.contains("\"double\":10.5"))
+        assertTrue(jsonString.contains("\"boolean\":true"))
+        assertTrue(jsonString.contains("\"map\":{\"key\":\"value\"}"))
+        assertTrue(jsonString.contains("\"list\":[\"value_1\",\"value_2\"]"))
+        assertTrue(jsonString.contains("\"array\":[\"value_1\",\"value_2\"]"))
+        assertNotNull(JSONObject(jsonString))
+    }
+
+    @Test
+    fun formatters_Default_FormatsString() {
+        val formatter: Formatter = HttpRemoteCommand.Formatters.formatterFor("application/json")
+        val formatted = formatter.format(testString, utf8)!!
+
+        assertEquals(testString, formatted.toString(utf8))
+    }
+
+    @Test
+    fun formatters_Default_FormatsUnknown() {
+        val formatter: Formatter = HttpRemoteCommand.Formatters.formatterFor("application/json")
+        val formatted = formatter.format(testObject, utf8)!!
+
+        assertEquals(testString, formatted.toString(utf8))
+    }
+
+    @Test
+    fun formatters_FormsFormatter_FormatsJson() {
+        val formatter: Formatter = HttpRemoteCommand.Formatters.formatterFor("application/x-www-form-urlencoded")
+        val formatted = formatter.format(testJsonObject, utf8)!!
+
+        val jsonString = formatted.toString(utf8)
+        assertTrue(jsonString.contains("string=value"))
+        assertTrue(jsonString.contains("int=10"))
+        assertTrue(jsonString.contains("double=10.5"))
+        assertTrue(jsonString.contains("boolean=true"))
+        assertTrue(jsonString.contains("map=%7B%22key%22%3A%22value%22%7D"))
+        assertTrue(jsonString.contains("list=%5B%22value_1%22%2C%22value_2%22%5D"))
+        assertTrue(jsonString.contains("array=%5B%22value_1%22%2C%22value_2%22%5D"))
+    }
+
+    @Test
+    fun formatters_FormsFormatter_FormatsString() {
+        val formatter: Formatter = HttpRemoteCommand.Formatters.formatterFor("application/x-www-form-urlencoded")
+        val formatted = formatter.format(testString, utf8)!!
+
+        assertEquals(testString, formatted.toString(utf8))
+    }
+
+    @Test
+    fun formatters_FormsFormatter_FormatsUnknown() {
+        val formatter: Formatter = HttpRemoteCommand.Formatters.formatterFor("application/x-www-form-urlencoded")
+        val formatted = formatter.format(testObject, utf8)!!
+
+        assertEquals(testString, formatted.toString(utf8))
+    }
+}

--- a/tagmanagementdispatcher/src/test/java/com/tealium/tagmanagementdispatcher/TagManagementDispatcherTest.kt
+++ b/tagmanagementdispatcher/src/test/java/com/tealium/tagmanagementdispatcher/TagManagementDispatcherTest.kt
@@ -1,6 +1,7 @@
 package com.tealium.tagmanagementdispatcher
 
 import android.app.Application
+import android.os.Build
 import android.webkit.CookieManager
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -20,9 +21,14 @@ import org.json.JSONStringer
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import java.io.File
 import java.net.URL
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [21, 28])
 class TagManagementDispatcherTest {
 
     @MockK
@@ -100,7 +106,7 @@ class TagManagementDispatcherTest {
             Pair(param.split("=")[0], param.split("=")[1])
         }
         assertEquals("android", queryParams[DeviceCollectorConstants.DEVICE_PLATFORM])
-        assertEquals(/* Build.VERSION.RELEASE */"null", queryParams[DeviceCollectorConstants.DEVICE_OS_VERSION])
+        assertEquals(Build.VERSION.RELEASE, queryParams[DeviceCollectorConstants.DEVICE_OS_VERSION])
         assertEquals(BuildConfig.VERSION_NAME, queryParams[CoreConstant.LIBRARY_VERSION])
         assertEquals("true", queryParams["sdk_session_count"])
     }
@@ -145,8 +151,6 @@ class TagManagementDispatcherTest {
     @Test
     fun dispatchReadyCallRemoteCommandTags() {
         val tagManagementDispatcher = TagManagementDispatcher(mockTealiumContext, mockDispatchSendCallbacks, mockConnectivity)
-        mockkConstructor(JSONStringer::class)
-        every { anyConstructed<JSONStringer>().toString() } returns ""
         val dispatch = TealiumEvent("test", mapOf("key" to "value"))
         tagManagementDispatcher.webViewLoader = mockWebViewLoader
         every { mockWebViewLoader.webViewStatus.get() } returns PageStatus.LOADED_SUCCESS

--- a/tealiumlibrary/src/main/java/com/tealium/dispatcher/Dispatch.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/dispatcher/Dispatch.kt
@@ -1,5 +1,6 @@
 package com.tealium.dispatcher
 
+import com.tealium.core.JsonUtils
 import org.json.JSONStringer
 
 interface Dispatch {
@@ -16,21 +17,7 @@ interface Dispatch {
     }
 
     fun toJsonString(): String {
-        val jsonStringer = JSONStringer()
-        jsonStringer.`object`()
-        payload().entries.forEach { entry ->
-            when (entry.value) {
-                is String -> encode(jsonStringer, entry.key, entry.value)
-                is Int -> encode(jsonStringer, entry.key, entry.value)
-                is Float -> encode(jsonStringer, entry.key, entry.value)
-                is Double -> encode(jsonStringer, entry.key, entry.value)
-                is Array<*> -> encodeCollection(jsonStringer, entry.key, entry.value)
-                is List<*> -> encodeCollection(jsonStringer, entry.key, entry.value)
-                else -> encodeString(jsonStringer, entry.key, entry.value)
-            }
-        }
-        jsonStringer.endObject()
-        return jsonStringer.toString()
+        return JsonUtils.jsonFor(payload()).toString()
     }
 
     fun encode(jsonStringer: JSONStringer, key: String, value: Any) {


### PR DESCRIPTION
 - Content-Type support for `application/json` as well as the existing `application/x-www-form-urlencoded`
 - Change in `Dispatch.toJsonString()` method to use existing `JsonUtils` - required TagManagement test updates