### PR TITLE
http client fixes

### DIFF
--- a/tealiumlibrary/build.gradle
+++ b/tealiumlibrary/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'kotlin-allopen'
 apply from: '../jacoco.gradle'
 
-version = '1.2.4'
+version = '1.2.5'
 
 android {
     compileSdkVersion 29

--- a/tealiumlibrary/src/test/java/com/tealium/core/network/HttpClientListenerTest.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/network/HttpClientListenerTest.kt
@@ -37,7 +37,7 @@ class HttpClientListenerTest {
         httpClient.post("test", "test_url", false)
 
         verify {
-            mockNetworkClientListener.onNetworkError("No network connection.")
+            mockNetworkClientListener.onNetworkError(any())
         }
         confirmVerified(mockNetworkClientListener)
     }

--- a/tealiumlibrary/src/test/java/com/tealium/core/network/HttpClientTest.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/network/HttpClientTest.kt
@@ -66,7 +66,7 @@ class HttpClientTest {
     }
 
     @Test
-    fun postSuccess() = runBlockingTest {
+    fun postSuccess() = runBlocking {
         every { mockConnectivity.isConnected() } returns true
         mockkStatic(URLUtil::class)
         every { URLUtil.isValidUrl(any()) } returns true
@@ -90,7 +90,7 @@ class HttpClientTest {
     }
 
     @Test
-    fun postFailsUnknownHost() = runBlockingTest {
+    fun postFailsUnknownHost() = runBlocking {
         every { mockConnectivity.isConnected() } returns true
         mockkStatic(URLUtil::class)
         every { URLUtil.isValidUrl(any()) } returns true

--- a/tealiumlibrary/src/test/java/com/tealium/core/settings/LibrarySettingsManagerTest.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/settings/LibrarySettingsManagerTest.kt
@@ -226,7 +226,7 @@ class LibrarySettingsManagerTest {
         coEvery { mockNetworkClient.get(any()) } returns jsonLibrarySettings
         val librarySettingsManager = LibrarySettingsManager(config, mockNetworkClient, mockLoader, eventRouter = mockEventRouter, backgroundScope = backgroundScope)
 
-        verify(exactly = 1, timeout = 1000) {
+        verify(exactly = 1, timeout = 1500) {
             mockEventRouter.onLibrarySettingsUpdated(any())
         }
 
@@ -259,7 +259,7 @@ class LibrarySettingsManagerTest {
         coEvery { mockNetworkClient.get(any()) } returns htmlLibrarySettings
         val librarySettingsManager = LibrarySettingsManager(config, mockNetworkClient, mockLoader, eventRouter = mockEventRouter, backgroundScope = backgroundScope)
 
-        coVerify(exactly = 1, timeout = 1000) {
+        coVerify(exactly = 1, timeout = 1500) {
             mockEventRouter.onLibrarySettingsUpdated(any())
         }
 


### PR DESCRIPTION
 - HttpClient BugFix - post failures where a listener was not supplied. Also fixes issues with consent logging failures.
 - HttpClient execution moved onto `IO` dispatcher for better asynchronous performance
 - Test updates