### PR TITLE
[MT-1223] - Geofences and permissions fixes

### DIFF
--- a/location/build.gradle
+++ b/location/build.gradle
@@ -3,15 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 apply from: '../jacoco.gradle'
 
-version = '1.1.1'
+version = '1.1.2'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
 
         buildConfigField 'String', 'TAG', "\"Tealium-Location-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""

--- a/location/src/main/AndroidManifest.xml
+++ b/location/src/main/AndroidManifest.xml
@@ -3,8 +3,13 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required only for Geofences -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application>
-        <receiver android:name=".GeofenceBroadcastReceiver"/>
+        <receiver
+            android:name=".GeofenceBroadcastReceiver"
+            android:exported="false"
+            />
     </application>
 </manifest>

--- a/location/src/main/java/com/tealium/location/FusedLocationProviderClientLoader.kt
+++ b/location/src/main/java/com/tealium/location/FusedLocationProviderClientLoader.kt
@@ -36,11 +36,9 @@ class FusedLocationProviderClientLoader(
                     val lastLocation = locationResult.lastLocation
                     _lastLocation = lastLocation
 
-                    // TODO - Configurable to possibly send event?
-                    val timestamp = Date()
                     Logger.dev(
                         BuildConfig.TAG,
-                        "${DateUtils.formatDate(timestamp)} - Received updated Location: lat=${lastLocation?.latitude},lng=${lastLocation?.longitude}"
+                        "Received updated Location: lat=${lastLocation?.latitude},lng=${lastLocation?.longitude}"
                     )
 
                     lastLocation?.let { lastLocationResult ->

--- a/location/src/main/java/com/tealium/location/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/java/com/tealium/location/GeofenceBroadcastReceiver.kt
@@ -34,7 +34,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             Geofence.GEOFENCE_TRANSITION_ENTER -> GeofenceTransitionType.ENTER
             Geofence.GEOFENCE_TRANSITION_EXIT -> GeofenceTransitionType.EXIT
             else -> {
-                Logger.dev(BuildConfig.TAG, "Error in geofence trasition type")
+                Logger.dev(BuildConfig.TAG, "Error in geofence transition type")
                 null
             }
         }

--- a/location/src/main/java/com/tealium/location/GeofenceLocationClient.kt
+++ b/location/src/main/java/com/tealium/location/GeofenceLocationClient.kt
@@ -22,8 +22,10 @@ class GeofenceLocationClient(private val context: TealiumContext) {
             context.config.application,
             0,
             LocationManager.fetchLocationIntent(context),
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) PendingIntent.FLAG_UPDATE_CURRENT else {
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
+                PendingIntent.FLAG_UPDATE_CURRENT
+            else {
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             }
         )
         try {

--- a/mobile/src/main/java/com/tealium/fragments/LocationFragment.kt
+++ b/mobile/src/main/java/com/tealium/fragments/LocationFragment.kt
@@ -2,6 +2,7 @@ package com.tealium.fragments
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -39,6 +40,20 @@ class LocationFragment : Fragment() {
 
     private fun requestLocationPermission() {
         activity?.let {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                if (ContextCompat.checkSelfPermission(
+                        it.applicationContext,
+                        Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                    ) != PackageManager.PERMISSION_GRANTED
+                ) {
+                    ActivityCompat.requestPermissions(
+                        it,
+                        Array<String>(1) { Manifest.permission.ACCESS_BACKGROUND_LOCATION },
+                        FINE_LOCATION_REQUEST_CODE
+                    )
+                }
+            }
+
             if (ContextCompat.checkSelfPermission(
                     it.applicationContext,
                     Manifest.permission.ACCESS_FINE_LOCATION


### PR DESCRIPTION
Location 1.1.2
 - Additional `ACCESS_BACKGROUND_LOCATION` permissions required for Geofences
 - Target SDK bumped to 33
 - BugFix - Switch to `PendingIntent.FLAG_MUTABLE`
 - BugFix - Removed reference to `DateUtils` obfuscated from the Core module.