### PR TITLE
[MT-1231] - Deep Link reporting updates

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-3940256099942544~3347511713"/>
-        <activity android:name="com.tealium.mobile.MainActivity">
+        <activity android:name="com.tealium.mobile.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/tealiumlibrary/src/main/java/com/tealium/core/DeepLinkHandler.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/DeepLinkHandler.kt
@@ -7,8 +7,13 @@ import com.tealium.core.messaging.ActivityObserverListener
 import com.tealium.core.persistence.Expiry
 import com.tealium.dispatcher.Dispatch
 import com.tealium.dispatcher.TealiumEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
-class DeepLinkHandler(private val context: TealiumContext) : ActivityObserverListener {
+class DeepLinkHandler(
+    private val context: TealiumContext,
+    private val backgroundScope: CoroutineScope
+) : ActivityObserverListener {
 
     /**
      * Adds the supplied Trace ID to the data layer for the current session.
@@ -37,11 +42,36 @@ class DeepLinkHandler(private val context: TealiumContext) : ActivityObserverLis
         context.track(dispatch)
     }
 
+    fun handleActivityResumed(activity: Activity) {
+        val intent = activity.intent ?: return
+        if (Intent.ACTION_VIEW != intent.action) return
+
+        val uri = intent.data ?: return
+        if (uri.isOpaque) return
+
+        if (context.config.qrTraceEnabled) {
+            uri.getQueryParameter(TRACE_ID_QUERY_PARAM)?.let { traceId ->
+                uri.getQueryParameter(KILL_VISITOR_SESSION)?.let {
+                    killTraceVisitorSession()
+                }
+                uri.getQueryParameter(LEAVE_TRACE_QUERY_PARAM)?.let {
+                    leaveTrace()
+                } ?: joinTrace(traceId)
+            }
+        }
+        if (context.config.deepLinkTrackingEnabled) {
+            handleDeepLink(uri)
+        }
+    }
+
     /**
      * If the app was launched from a deep link, adds the link and query parameters to the data layer for the current session.
      */
     fun handleDeepLink(uri: Uri) {
         if (uri.isOpaque || uri == Uri.EMPTY) return
+
+        val oldDeepLink = context.dataLayer.getString(Dispatch.Keys.DEEP_LINK_URL)
+        if (uri.toString() == oldDeepLink) return
 
         removeOldDeepLinkData()
         context.dataLayer.putString(Dispatch.Keys.DEEP_LINK_URL, uri.toString(), Expiry.SESSION)
@@ -74,26 +104,9 @@ class DeepLinkHandler(private val context: TealiumContext) : ActivityObserverLis
      * Handles deep linking and joinTrace, leaveTrace, killVisitorSession requests.
      */
     override fun onActivityResumed(activity: Activity?) {
-        activity?.intent?.let { intent ->
-            if (Intent.ACTION_VIEW != intent.action)
-                return
-
-            intent.data?.let { uri ->
-                if (uri.isOpaque) return
-
-                if (context.config.qrTraceEnabled) {
-                    uri.getQueryParameter(TRACE_ID_QUERY_PARAM)?.let { traceId ->
-                        uri.getQueryParameter(KILL_VISITOR_SESSION)?.let {
-                            killTraceVisitorSession()
-                        }
-                        uri.getQueryParameter(LEAVE_TRACE_QUERY_PARAM)?.let {
-                            leaveTrace()
-                        } ?: joinTrace(traceId)
-                    }
-                }
-                if (context.config.deepLinkTrackingEnabled) {
-                    handleDeepLink(uri)
-                }
+        activity?.let {
+            backgroundScope.launch {
+                handleActivityResumed(it)
             }
         }
     }

--- a/tealiumlibrary/src/main/java/com/tealium/core/DeepLinkHandler.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/DeepLinkHandler.kt
@@ -1,6 +1,7 @@
 package com.tealium.core
 
 import android.app.Activity
+import android.content.Intent
 import android.net.Uri
 import com.tealium.core.messaging.ActivityObserverListener
 import com.tealium.core.persistence.Expiry
@@ -40,7 +41,7 @@ class DeepLinkHandler(private val context: TealiumContext) : ActivityObserverLis
      * If the app was launched from a deep link, adds the link and query parameters to the data layer for the current session.
      */
     fun handleDeepLink(uri: Uri) {
-        if (uri.isOpaque) return
+        if (uri.isOpaque || uri == Uri.EMPTY) return
 
         removeOldDeepLinkData()
         context.dataLayer.putString(Dispatch.Keys.DEEP_LINK_URL, uri.toString(), Expiry.SESSION)
@@ -74,6 +75,9 @@ class DeepLinkHandler(private val context: TealiumContext) : ActivityObserverLis
      */
     override fun onActivityResumed(activity: Activity?) {
         activity?.intent?.let { intent ->
+            if (Intent.ACTION_VIEW != intent.action)
+                return
+
             intent.data?.let { uri ->
                 if (uri.isOpaque) return
 

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -174,7 +174,7 @@ class Tealium private constructor(
         // Subscribe user event listeners
         eventRouter.subscribeAll(config.events.toList())
 
-        deepLinkHandler = DeepLinkHandler(context)
+        deepLinkHandler = DeepLinkHandler(context, backgroundScope)
         eventRouter.subscribeAll(listOf(Logger, sessionManager, deepLinkHandler))
         timedEvents = TimedEventsManager(context)
 

--- a/tealiumlibrary/src/test/java/com/tealium/core/DeepLinkHandlerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/DeepLinkHandlerTests.kt
@@ -95,6 +95,7 @@ class DeepLinkHandlerTests {
 
         intent = Intent()
         every { mockActivity.intent } returns intent
+        intent.action = Intent.ACTION_VIEW
     }
 
     fun setupUriBuilder() {
@@ -165,6 +166,74 @@ class DeepLinkHandlerTests {
                 "deep_link_url",
                 uri.toString(),
                 Expiry.SESSION
+            )
+        }
+    }
+
+    @Test
+    fun testHandleDeepLinkIgnoresIncorrectActions() {
+        every { mockContext.config } returns configWithDeepLinkingEnabled
+        val mockActivityObserverListener = DeepLinkHandler(mockContext)
+        setupUriBuilder()
+
+        intent.data = uri
+        intent.action = Intent.ACTION_TRANSLATE
+        runBlocking {
+            mockActivityObserverListener.onActivityResumed(mockActivity)
+            delay(100)
+        }
+
+        verify(inverse = true) {
+            mockDataLayer.putString(
+                "deep_link_url",
+                uri.toString(),
+                Expiry.SESSION
+            )
+        }
+    }
+
+    @Test
+    fun testHandleDeepLinkIgnoresNullActions() {
+        every { mockContext.config } returns configWithDeepLinkingEnabled
+        val mockActivityObserverListener = DeepLinkHandler(mockContext)
+        setupUriBuilder()
+
+        intent.data = uri
+        intent.action = null
+        runBlocking {
+            mockActivityObserverListener.onActivityResumed(mockActivity)
+            delay(100)
+        }
+
+        verify(inverse = true) {
+            mockDataLayer.putString(
+                "deep_link_url",
+                uri.toString(),
+                Expiry.SESSION
+            )
+        }
+    }
+
+    @Test
+    fun testHandleDeepLinkIgnoresEmptyUris() {
+        every { mockContext.config } returns configWithDeepLinkingEnabled
+        val mockActivityObserverListener = DeepLinkHandler(mockContext)
+        setupUriBuilder()
+
+        intent.data = Uri.parse("")
+        runBlocking {
+            mockActivityObserverListener.onActivityResumed(mockActivity)
+            delay(100)
+        }
+
+        verify(inverse = true) {
+            mockDataLayer.putString(
+                "deep_link_url",
+                any(),
+                Expiry.SESSION
+            )
+            mockDataLayer.remove(
+                any()
             )
         }
     }


### PR DESCRIPTION
 - Deep Link handling limited to Activities launched with Intents where `action == Intent.ACTION_VIEW`
 - Empty Uris are ignored, and deep links that match what is already stored is a no-op
 - Handling pushed onto Tealium background thread. 