### PR TITLE
Lifecycle 1.2.0

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run Unit Tests
-    runs-on: macos-10.15
+    runs-on: macos-latest
     strategy:
       matrix:
         api-level: [21, 29]
@@ -24,12 +24,9 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot-save -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./run_instrumented_tests.sh
-      - name: Test Coverage
-        continue-on-error: true
-        run: ./verify_coverage.sh
+          script: ./run_instrumented_tests.sh && ./verify_coverage.sh
       - name: Upload Reports
         continue-on-error: true
         uses: actions/upload-artifact@v2

--- a/lifecycle/build.gradle
+++ b/lifecycle/build.gradle
@@ -3,15 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 apply from: '../jacoco.gradle'
 
-version = '1.1.1'
+version = '1.2.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/lifecycle/src/main/java/com/tealium/lifecycle/Lifecycle.kt
+++ b/lifecycle/src/main/java/com/tealium/lifecycle/Lifecycle.kt
@@ -96,7 +96,8 @@ class Lifecycle(private val context: TealiumContext) : Collector, ActivityObserv
         onForegrounding(LifecycleEvent.LAUNCH, state, timestamp)
         lifecycleSharedPreferences.lastLifecycleEvent = LifecycleEvent.LAUNCH
 
-        state[LifecycleStateKey.LIFECYCLE_PRIORSECONDSAWAKE] = lifecycleSharedPreferences.priorSecondsAwake
+        state[LifecycleStateKey.LIFECYCLE_PRIORSECONDSAWAKE] =
+            lifecycleSharedPreferences.priorSecondsAwake
 
         if (isFirstLaunch) {
             state[LifecycleStateKey.LIFECYCLE_ISFIRSTLAUNCH] = (true).toString()
@@ -128,8 +129,9 @@ class Lifecycle(private val context: TealiumContext) : Collector, ActivityObserv
     }
 
     private fun trackSleepEvent(timestamp: Long, data: Map<String, Any>? = null) {
-        val foregroundStart: Long = if (lifecycleSharedPreferences.timestampLastWake > LifecycleDefaults.TIMESTAMP_INVALID) lifecycleSharedPreferences.timestampLastWake
-        else LifecycleDefaults.TIMESTAMP_INVALID
+        val foregroundStart: Long =
+            if (lifecycleSharedPreferences.timestampLastWake > LifecycleDefaults.TIMESTAMP_INVALID) lifecycleSharedPreferences.timestampLastWake
+            else LifecycleDefaults.TIMESTAMP_INVALID
         val secondsAwakeDelta: Int = ((timestamp - foregroundStart) / 1000L).toInt()
         lifecycleSharedPreferences.incrementSleep()
         lifecycleSharedPreferences.updateSecondsAwake(secondsAwakeDelta)
@@ -163,7 +165,8 @@ class Lifecycle(private val context: TealiumContext) : Collector, ActivityObserv
 
         if (lifecycleService.didDetectCrash(eventName)) {
             data[LifecycleStateKey.LIFECYCLE_DIDDETECTCRASH] = (true).toString()
-            data[LifecycleStateKey.LIFECYCLE_TOTALCRASHCOUNT] = lifecycleSharedPreferences.countTotalCrash
+            data[LifecycleStateKey.LIFECYCLE_TOTALCRASHCOUNT] =
+                lifecycleSharedPreferences.countTotalCrash
         }
 
         val isFirstWakeResult = lifecycleService.isFirstWake(lastWake, timestamp)
@@ -212,7 +215,11 @@ class Lifecycle(private val context: TealiumContext) : Collector, ActivityObserv
         val eventData = mapOf<String, Any>(LifecycleStateKey.AUTOTRACKED to true)
 
         if (lastResume == LifecycleDefaults.TIMESTAMP_INVALID) {
-            trackLaunchEvent(lifecycleSharedPreferences.timestampLastLaunch, eventData)
+            val timestampLastLaunch = LifecycleService.validOrDefault(
+                timestamp = lifecycleSharedPreferences.timestampLastLaunch,
+                default = System.currentTimeMillis()
+            )
+            trackLaunchEvent(timestampLastLaunch, eventData)
         }
 
         lifecycleSharedPreferences.lastLifecycleEvent = LifecycleEvent.PAUSE

--- a/lifecycle/src/main/java/com/tealium/lifecycle/LifecycleService.kt
+++ b/lifecycle/src/main/java/com/tealium/lifecycle/LifecycleService.kt
@@ -5,9 +5,6 @@ import java.util.*
 
 internal class LifecycleService(private val lifecycleSharedPreferences: LifecycleSharedPreferences) {
 
-    private val IS_FIRST_WAKE_MONTH = 1
-    private val IS_FIRST_WAKE_TODAY = 1 shl 1
-
     private val calendar: Calendar = Calendar.getInstance()
     var formatIso8601 = SimpleDateFormat(LifecycleDefaults.FORMAT_ISO_8601, Locale.ROOT)
     var reusableDate: Date = Date(LifecycleDefaults.TIMESTAMP_INVALID)
@@ -19,8 +16,24 @@ internal class LifecycleService(private val lifecycleSharedPreferences: Lifecycl
     fun getCurrentState(timestamp: Long): MutableMap<String, Any> {
         val data = mutableMapOf<String, Any>(
             LifecycleStateKey.LIFECYCLE_DAYOFWEEK_LOCAL to getDayOfWeekLocal(timestamp),
-            LifecycleStateKey.LIFECYCLE_DAYSSINCELAUNCH to ((timestamp - lifecycleSharedPreferences.timestampFirstLaunch) / LifecycleDefaults.DAY_IN_MS).toString(),
-            LifecycleStateKey.LIFECYCLE_DAYSSINCELASTWAKE to (if (lifecycleSharedPreferences.timestampLastWake == LifecycleDefaults.TIMESTAMP_INVALID) "0" else ((timestamp - lifecycleSharedPreferences.timestampLastWake) / LifecycleDefaults.DAY_IN_MS).toString()),
+            LifecycleStateKey.LIFECYCLE_DAYSSINCELAUNCH to lifecycleSharedPreferences.timestampFirstLaunch.let { firstLaunch ->
+                daysSince(
+                    startEventMs = firstLaunch,
+                    endEventMs = timestamp
+                ).toString()
+            },
+            LifecycleStateKey.LIFECYCLE_DAYSSINCELASTWAKE to lifecycleSharedPreferences.timestampLastWake.let { lastWake ->
+                daysSince(
+                    startEventMs = lastWake,
+                    endEventMs = timestamp
+                ).toString()
+            },
+            LifecycleStateKey.LIFECYCLE_DAYSSINCEUPDATE to lifecycleSharedPreferences.timestampUpdate.let { lastUpdate ->
+                daysSince(
+                    startEventMs = lastUpdate,
+                    endEventMs = timestamp
+                ).toString()
+            },
             LifecycleStateKey.LIFECYCLE_HOUROFDAY_LOCAL to getHourOfDayLocal(timestamp).toString(),
             LifecycleStateKey.LIFECYCLE_LAUNCHCOUNT to lifecycleSharedPreferences.countLaunch,
             LifecycleStateKey.LIFECYCLE_SLEEPCOUNT to lifecycleSharedPreferences.countSleep,
@@ -29,14 +42,13 @@ internal class LifecycleService(private val lifecycleSharedPreferences: Lifecycl
             LifecycleStateKey.LIFECYCLE_TOTALLAUNCHCOUNT to lifecycleSharedPreferences.countTotalLaunch,
             LifecycleStateKey.LIFECYCLE_TOTALSLEEPCOUNT to lifecycleSharedPreferences.countSleep.toString(),
             LifecycleStateKey.LIFECYCLE_TOTALWAKECOUNT to lifecycleSharedPreferences.countWake.toString(),
-            LifecycleStateKey.LIFECYCLE_TOTALSECONDSAWAKE to lifecycleSharedPreferences.totalSecondsAwake.toString(),
-            LifecycleStateKey.LIFECYCLE_DAYSSINCEUPDATE to ((timestamp - lifecycleSharedPreferences.timestampUpdate) / LifecycleDefaults.DAY_IN_MS).toString()
+            LifecycleStateKey.LIFECYCLE_TOTALSECONDSAWAKE to lifecycleSharedPreferences.totalSecondsAwake.toString()
         )
 
         lifecycleSharedPreferences.firstLaunch?.let {
             data[LifecycleStateKey.LIFECYCLE_FIRSTLAUNCHDATE] = it
         } ?: run {
-            val launch = lifecycleSharedPreferences.setFirstLaunch()
+            val launch = lifecycleSharedPreferences.setFirstLaunch(timestamp)
             launch?.let {
                 data[LifecycleStateKey.LIFECYCLE_FIRSTLAUNCHDATE] = it
             }
@@ -45,7 +57,7 @@ internal class LifecycleService(private val lifecycleSharedPreferences: Lifecycl
         lifecycleSharedPreferences.firstLaunchMmDdYyyy?.let {
             data[LifecycleStateKey.LIFECYCLE_FIRSTLAUNCHDATE_MMDDYYYY] = it
         } ?: run {
-            val launchDataMmDdYyyy = lifecycleSharedPreferences.setFirstLaunchMmDdYyyy()
+            val launchDataMmDdYyyy = lifecycleSharedPreferences.setFirstLaunchMmDdYyyy(timestamp)
             launchDataMmDdYyyy?.let {
                 data[LifecycleStateKey.LIFECYCLE_FIRSTLAUNCHDATE_MMDDYYYY] = it
             }
@@ -81,8 +93,6 @@ internal class LifecycleService(private val lifecycleSharedPreferences: Lifecycl
         if (lifecycleSharedPreferences.timestampUpdate != LifecycleDefaults.TIMESTAMP_INVALID) {
             lifecycleSharedPreferences.updateLaunchDate?.let {
                 data[LifecycleStateKey.LIFECYCLE_UPDATELAUNCHDATE] = it
-                data[LifecycleStateKey.LIFECYCLE_DAYSSINCEUPDATE] =
-                    ((timestamp - lifecycleSharedPreferences.timestampUpdate) / LifecycleDefaults.DAY_IN_MS)
             } ?: run {
                 lifecycleSharedPreferences.updateLaunchDate = getUpdateLaunchDate()
             }
@@ -125,16 +135,14 @@ internal class LifecycleService(private val lifecycleSharedPreferences: Lifecycl
     fun didUpdate(timestamp: Long, initializedCurrentVersion: String): Boolean {
         val cachedVersion = lifecycleSharedPreferences.currentAppVersion
 
-        if (initializedCurrentVersion != cachedVersion) {
+        if (cachedVersion == null) {
+            lifecycleSharedPreferences.currentAppVersion = initializedCurrentVersion
+        } else if (initializedCurrentVersion != cachedVersion) {
             lifecycleSharedPreferences.resetCountsAfterAppUpdate(
                 timestamp,
                 initializedCurrentVersion
             )
             return true
-        }
-
-        if (cachedVersion.isNullOrEmpty()) {
-            lifecycleSharedPreferences.currentAppVersion = initializedCurrentVersion
         }
 
         return false
@@ -207,5 +215,50 @@ internal class LifecycleService(private val lifecycleSharedPreferences: Lifecycl
 
     fun isFirstWakeToday(firstWake: Int): Boolean {
         return firstWake and IS_FIRST_WAKE_TODAY == IS_FIRST_WAKE_TODAY
+    }
+
+    companion object {
+
+        private const val IS_FIRST_WAKE_MONTH = 1
+        private const val IS_FIRST_WAKE_TODAY = 1 shl 1
+
+        /**
+         * If [timestamp] is valid, i.e. that it is not equal to [LifecycleDefaults.TIMESTAMP_INVALID]
+         * then it returns the [valid] value, else the [default] provided.
+         *
+         * @param timestamp The timestamp to check the validity of
+         * @param default The result to return if [timestamp] is invalid
+         * @param valid The result to return if valid; defaults to the provided [timestamp]
+         */
+        internal fun validOrDefault(timestamp: Long, default: Long, valid: Long = timestamp): Long {
+            return if (timestamp != LifecycleDefaults.TIMESTAMP_INVALID)
+                valid
+            else
+                default
+        }
+
+        /**
+         * Calculates the number of days, as a whole number of days, between two events recorded in
+         * milliseconds.
+         *
+         * [startEventMs] and [endEventMs] should be positive numbers, but all results will be at
+         * least 0.
+         */
+        internal fun daysSince(startEventMs: Long, endEventMs: Long): Long {
+            if (startEventMs == LifecycleDefaults.TIMESTAMP_INVALID ||
+                endEventMs == LifecycleDefaults.TIMESTAMP_INVALID
+            ) {
+                return 0L
+            }
+
+            val positiveStartMs = startEventMs.coerceAtLeast(0L)
+            val positiveEndMs = endEventMs.coerceAtLeast(0L)
+            val deltaMs = if (positiveEndMs <= positiveStartMs) {
+                0L
+            } else {
+                positiveEndMs - positiveStartMs
+            }
+            return (deltaMs / LifecycleDefaults.DAY_IN_MS)
+        }
     }
 }

--- a/lifecycle/src/main/java/com/tealium/lifecycle/LifecycleSharedPreferences.kt
+++ b/lifecycle/src/main/java/com/tealium/lifecycle/LifecycleSharedPreferences.kt
@@ -127,16 +127,18 @@ internal class LifecycleSharedPreferences(
         secondsAwakeSinceLaunch += seconds
     }
 
-    fun setFirstLaunch(): String? {
-        reusableDate.time = timestampFirstLaunch
+    @JvmOverloads
+    fun setFirstLaunch(fallbackTimestamp: Long = System.currentTimeMillis()): String? {
+        reusableDate.time = LifecycleService.validOrDefault(timestampFirstLaunch, fallbackTimestamp)
         firstLaunch = formatIso8601.format(reusableDate)
         return firstLaunch
     }
 
-    fun setFirstLaunchMmDdYyyy(): String? {
+    @JvmOverloads
+    fun setFirstLaunchMmDdYyyy(fallbackTimestamp: Long = System.currentTimeMillis()): String? {
         val formatMmDdYyyy = SimpleDateFormat("MM/dd/yyy", Locale.ROOT)
         formatMmDdYyyy.timeZone = TimeZone.getTimeZone("UTC")
-        reusableDate.time = timestampFirstLaunch
+        reusableDate.time = LifecycleService.validOrDefault(timestampFirstLaunch, fallbackTimestamp)
         firstLaunchMmDdYyyy = formatMmDdYyyy.format(reusableDate)
 
         return firstLaunchMmDdYyyy

--- a/lifecycle/src/test/java/com/tealium/lifecycle/LifecycleSharedPreferencesTest.kt
+++ b/lifecycle/src/test/java/com/tealium/lifecycle/LifecycleSharedPreferencesTest.kt
@@ -10,6 +10,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.util.*
@@ -316,4 +317,41 @@ class LifecycleSharedPreferencesTest {
             mockEditor.apply()
         }
     }
+
+    @Test
+    fun setFirstLaunch_ReturnsCurrentDate_WhenInvalidTimestamp() {
+        every {
+            mockSharedPreferences.getLong(
+                LifecycleSPKey.TIMESTAMP_FIRST_LAUNCH,
+                any()
+            )
+        } returns LifecycleDefaults.TIMESTAMP_INVALID
+
+        val currentDate = Date(System.currentTimeMillis())
+
+        val spykLifecycleSharedPreferences = spyk(lifecycleSharedPreferences)
+        val firstLaunchDate = spykLifecycleSharedPreferences.setFirstLaunch()
+
+        assertTrue(firstLaunchDate!!.startsWith(currentDate.absoluteYear.toString()))
+    }
+
+    @Test
+    fun setFirstLaunchMmDdYyyy_ReturnsCurrentDate_WhenInvalidTimestamp() {
+        every {
+            mockSharedPreferences.getLong(
+                LifecycleSPKey.TIMESTAMP_FIRST_LAUNCH,
+                any()
+            )
+        } returns LifecycleDefaults.TIMESTAMP_INVALID
+
+        val currentDate = Date(System.currentTimeMillis())
+
+        val spykLifecycleSharedPreferences = spyk(lifecycleSharedPreferences)
+        val firstLaunchDdMmYyyy = spykLifecycleSharedPreferences.setFirstLaunchMmDdYyyy()
+
+        assertTrue(firstLaunchDdMmYyyy!!.endsWith(currentDate.absoluteYear.toString()))
+    }
+
+    private val Date.absoluteYear: Int
+        get() = this.year + 1900
 }

--- a/lifecycle/src/test/java/com/tealium/lifecycle/LifecycleTest.kt
+++ b/lifecycle/src/test/java/com/tealium/lifecycle/LifecycleTest.kt
@@ -47,16 +47,36 @@ class LifecycleTest {
         every { anyConstructed<TealiumConfig>().tealiumDirectory.mkdir() } returns mockk()
 
         config = TealiumConfig(context, "test", "profile", Environment.QA)
-        every { config.application.getSharedPreferences(any(), any()) } returns mockSharedPreferences
+        every {
+            config.application.getSharedPreferences(
+                any(),
+                any()
+            )
+        } returns mockSharedPreferences
 
         mockPackageInfo = spyk(PackageInfo())
         every { config.application.packageName } returns "test"
-        every { config.application.packageManager.getPackageInfo(any<String>(), any()) } returns mockPackageInfo
+        every {
+            config.application.packageManager.getPackageInfo(
+                any<String>(),
+                any<Int>()
+            )
+        } returns mockPackageInfo
 
 
         mockkConstructor(SharedPreferences::class)
-        every { anyConstructed<SharedPreferences>().getInt(LifecycleSPKey.COUNT_LAUNCH, 1) } returns 1
-        every { anyConstructed<SharedPreferences>().getInt(LifecycleSPKey.COUNT_SLEEP, 1) } returns 1
+        every {
+            anyConstructed<SharedPreferences>().getInt(
+                LifecycleSPKey.COUNT_LAUNCH,
+                1
+            )
+        } returns 1
+        every {
+            anyConstructed<SharedPreferences>().getInt(
+                LifecycleSPKey.COUNT_SLEEP,
+                1
+            )
+        } returns 1
         every { anyConstructed<SharedPreferences>().getInt(LifecycleSPKey.COUNT_WAKE, 1) } returns 1
         every { anyConstructed<SharedPreferences>().edit() } returns editor
         every { editor.apply() } just Runs


### PR DESCRIPTION
 - Fix: Incorrect first launch dates on events sent prior to the first launch. More easily reproducible when lifecycle autotracking is disabled.
 - Fix: Negative `lifecycle_dayssinceXXX` values 
 - Fix: `lifecycle_firstlaunchupdate` removed from the initial first launch