### PR TITLE
Add destructive migration to database downgrade

### DIFF
--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/persistence/DatabaseMigrationTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/persistence/DatabaseMigrationTests.kt
@@ -1,0 +1,51 @@
+package com.tealium.core.persistence
+
+import android.app.Application
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tealium.core.Environment
+import com.tealium.core.TealiumConfig
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseMigrationTests {
+
+    @Test
+    fun testUpgrade_1_2() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val config = TealiumConfig(context, "test", "profile", Environment.QA)
+
+        val databaseHelper = DatabaseHelper(config, databaseVersion = 1)
+        val db = SQLiteDatabase.create(null)
+
+        databaseHelper.onCreate(db)
+
+        databaseHelper.onUpgrade(db, 1, 2)
+
+        // Verify all 3 tables created
+        db.rawQuery("SELECT * FROM datalayer", emptyArray())
+        db.rawQuery("SELECT * FROM dispatches", emptyArray())
+        db.rawQuery("SELECT * FROM visitors", emptyArray())
+    }
+
+    @Test
+    fun testDowngrade_3_2() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val config = TealiumConfig(context, "test", "profile", Environment.QA)
+
+        val databaseHelper = DatabaseHelper(config, databaseVersion = 3)
+        val db = SQLiteDatabase.create(null)
+
+        databaseHelper.onCreate(db)
+
+        databaseHelper.onDowngrade(db, 3, 2)
+
+        // Verify all 3 tables created
+        db.rawQuery("SELECT * FROM datalayer", emptyArray())
+        db.rawQuery("SELECT * FROM dispatches", emptyArray())
+        db.rawQuery("SELECT * FROM visitors", emptyArray())
+    }
+}

--- a/tealiumlibrary/src/main/java/com/tealium/core/persistence/DatabaseHelper.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/persistence/DatabaseHelper.kt
@@ -10,14 +10,17 @@ import java.io.File
  * the [config] parameter.
  * @param config - TealiumConfig item with
  */
-internal class DatabaseHelper(config: TealiumConfig, databaseName: String? = databaseName(config)) :
-    SQLiteOpenHelper(config.application.applicationContext, databaseName, null, DATABASE_VERSION) {
+internal class DatabaseHelper(
+        config: TealiumConfig,
+        databaseName: String? = databaseName(config),
+        private val databaseVersion: Int = DATABASE_VERSION
+) : SQLiteOpenHelper(config.application.applicationContext, databaseName, null, databaseVersion) {
 
     override fun onCreate(db: SQLiteDatabase?) {
         db?.execSQL(SqlDataLayer.Sql.getCreateTableSql("datalayer"))
         db?.execSQL(SqlDataLayer.Sql.getCreateTableSql("dispatches"))
         // apply all necessary upgrades
-        onUpgrade(db, 1, DATABASE_VERSION)
+        onUpgrade(db, 1, databaseVersion)
     }
 
     override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
@@ -26,6 +29,14 @@ internal class DatabaseHelper(config: TealiumConfig, databaseName: String? = dat
                 it.upgrade(database)
             }
         }
+    }
+
+    override fun onDowngrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
+        db?.execSQL(SqlDataLayer.Sql.getDeleteTableSql("datalayer"))
+        db?.execSQL(SqlDataLayer.Sql.getDeleteTableSql("dispatches"))
+        db?.execSQL(SqlDataLayer.Sql.getDeleteTableSql("visitors"))
+
+        onCreate(db)
     }
 
     companion object {

--- a/tealiumlibrary/src/main/java/com/tealium/core/persistence/SqlDataLayer.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/persistence/SqlDataLayer.kt
@@ -21,5 +21,9 @@ object SqlDataLayer {
                     "${Columns.COLUMN_TIMESTAMP} LONG, " +
                     "${Columns.COLUMN_TYPE} SMALLINT)"
         }
+
+        fun getDeleteTableSql(tableName: String): String {
+            return "DROP TABLE $tableName"
+        }
     }
 }


### PR DESCRIPTION
Added a destructive migration whenever db downgrade from any versions.

This might not really be scalable as we need to add one more drop table in `onDowngrade` we have new table. A better solution might be to query the sqlite master table for tables names then recursively drop them one by one. Since we only have 3 tables for now, I made a conscious decision not to do early abstraction.

I also added a integration test with the database to make sure the downgrade and upgrade went smoothly.