### PR TITLE
MT-1323: Update module targetSdk to 33

### DIFF
--- a/adidentifier/build.gradle
+++ b/adidentifier/build.gradle
@@ -6,11 +6,11 @@ apply from: '../jacoco.gradle'
 version = '1.1.0'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-AdIdentifier-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 

--- a/autotracking/build.gradle
+++ b/autotracking/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = "1.0.0"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-AutoTracking-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 

--- a/collectdispatcher/build.gradle
+++ b/collectdispatcher/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = '1.1.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-CollectDispatcher-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 

--- a/crashreporter/build.gradle
+++ b/crashreporter/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = '1.1.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-CrashReporter-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 

--- a/hosteddatalayer/build.gradle
+++ b/hosteddatalayer/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = '1.1.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
 
         buildConfigField 'String', 'TAG', "\"Tealium-HostedDataLayer-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""

--- a/inapppurchase/build.gradle
+++ b/inapppurchase/build.gradle
@@ -7,12 +7,12 @@ plugins {
 version = '1.0.1'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         buildConfigField 'String', 'TAG', "\"Tealium-InAppPurchaseTracker-$version\""

--- a/installreferrer/build.gradle
+++ b/installreferrer/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = '1.1.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-InstallReferrer-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 

--- a/media/build.gradle
+++ b/media/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = '1.1.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-Media-$version\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/remotecommanddispatcher/build.gradle
+++ b/remotecommanddispatcher/build.gradle
@@ -7,12 +7,12 @@ apply from: '../jacoco.gradle'
 version = '1.3.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         buildConfigField 'String', 'TAG', "\"Tealium-RemoteCommandDispatcher-$version\""
         buildConfigField 'String', 'LIBRARY_VERSION', "\"$version\""
 

--- a/tagmanagementdispatcher/build.gradle
+++ b/tagmanagementdispatcher/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 apply from: '../jacoco.gradle'
 
-version = '1.2.0'
+version = '1.2.1'
 
 android {
     compileSdkVersion 33

--- a/tagmanagementdispatcher/build.gradle
+++ b/tagmanagementdispatcher/build.gradle
@@ -6,12 +6,12 @@ apply from: '../jacoco.gradle'
 version = '1.2.0'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
 
         buildConfigField 'String', 'TAG', "\"Tealium-TagManagementDispatcher-$version\""
         buildConfigField 'String', 'VERSION_NAME', "\"$version\""

--- a/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
+++ b/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
@@ -299,8 +299,6 @@ class WebViewLoader(
                     javaScriptEnabled = true
                     domStorageEnabled = true
                     cacheMode = WebSettings.LOAD_DEFAULT
-//                    setAppCacheEnabled(true)
-//                    setAppCachePath(context.config.tealiumDirectory.absolutePath)
                 }
 
                 // unrendered webview, disable hardware acceleration

--- a/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
+++ b/tagmanagementdispatcher/src/main/java/com/tealium/tagmanagementdispatcher/WebViewLoader.kt
@@ -298,8 +298,9 @@ class WebViewLoader(
                     databaseEnabled = true
                     javaScriptEnabled = true
                     domStorageEnabled = true
-                    setAppCacheEnabled(true)
-                    setAppCachePath(context.config.tealiumDirectory.absolutePath)
+                    cacheMode = WebSettings.LOAD_DEFAULT
+//                    setAppCacheEnabled(true)
+//                    setAppCachePath(context.config.tealiumDirectory.absolutePath)
                 }
 
                 // unrendered webview, disable hardware acceleration


### PR DESCRIPTION
- Update module targetSdk to 33
- TagManagement - update webView.settings cacheMode to be compatible with sdk 33. appCacheEnable and appCachePath methods [removed in sdk 33](https://developer.android.com/sdk/api_diff/33/changes).