### PR TITLE
AdIdentifier DI rework + Robolectric test versions updated

### DIFF
--- a/adidentifier/build.gradle
+++ b/adidentifier/build.gradle
@@ -39,7 +39,10 @@ android {
     }
 
     testOptions {
-        unitTests.returnDefaultValues = true
+        unitTests {
+            returnDefaultValues = true
+            includeAndroidResources = true
+        }
     }
 }
 

--- a/adidentifier/src/main/java/com/tealium/adidentifier/AdIdentifier.kt
+++ b/adidentifier/src/main/java/com/tealium/adidentifier/AdIdentifier.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import com.google.android.gms.appset.AppSet
+import com.google.android.gms.appset.AppSetIdClient
 import com.tealium.core.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -13,7 +14,11 @@ import java.lang.Exception
 /**
  * Module to retrieve Advertising ID from Google Play and save to Data Layer
  */
-class AdIdentifier(private val tealiumContext: TealiumContext) : Module {
+class AdIdentifier(
+    private val tealiumContext: TealiumContext,
+    private val adidInfoProvider: (Context) -> AdvertisingIdClient.Info = AdvertisingIdClient::getAdvertisingIdInfo,
+    private val appSetClientProvider: (Context) -> AppSetIdClient = AppSet::getClient
+) : Module {
 
     override val name: String
         get() = MODULE_NAME
@@ -85,7 +90,7 @@ class AdIdentifier(private val tealiumContext: TealiumContext) : Module {
      */
     private fun fetchAdInfo(context: Context) {
         try {
-            val adInfo = AdvertisingIdClient.getAdvertisingIdInfo(context)
+            val adInfo = adidInfoProvider.invoke(context)
             if (adInfo.id != null) {
                 adid = adInfo.id
             }
@@ -96,14 +101,12 @@ class AdIdentifier(private val tealiumContext: TealiumContext) : Module {
     }
 
     private fun fetchAppSetInfo(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val client = AppSet.getClient(context)
-            val task = client.appSetIdInfo
+        val client = appSetClientProvider.invoke(context)
+        val task = client.appSetIdInfo
 
-            task.addOnSuccessListener {
-                appSetId = it.id
-                appSetScope = it.scope
-            }
+        task.addOnSuccessListener {
+            appSetId = it.id
+            appSetScope = it.scope
         }
     }
 

--- a/adidentifier/src/main/java/com/tealium/adidentifier/AdIdentifier.kt
+++ b/adidentifier/src/main/java/com/tealium/adidentifier/AdIdentifier.kt
@@ -1,7 +1,6 @@
 package com.tealium.adidentifier
 
 import android.content.Context
-import android.os.Build
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import com.google.android.gms.appset.AppSet
 import com.google.android.gms.appset.AppSetIdClient

--- a/adidentifier/src/test/java/com/tealium/adidentifier/AdIdentifierTests.kt
+++ b/adidentifier/src/test/java/com/tealium/adidentifier/AdIdentifierTests.kt
@@ -1,10 +1,11 @@
 package com.tealium.adidentifier
 
 import android.app.Application
+import android.content.Context
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
-import com.google.android.gms.appset.AppSet
 import com.google.android.gms.appset.AppSetIdClient
 import com.google.android.gms.appset.AppSetIdInfo
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
 import com.google.android.gms.tasks.Task
 import com.tealium.core.TealiumConfig
 import com.tealium.core.TealiumContext
@@ -16,7 +17,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class AdIdentifierTests {
@@ -42,6 +42,9 @@ class AdIdentifierTests {
     @MockK
     lateinit var appSetIdInfo: AppSetIdInfo
 
+    private lateinit var adidProvider: (Context) -> AdvertisingIdClient.Info
+    private lateinit var appSetClientProvider: (Context) -> AppSetIdClient
+
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
@@ -52,9 +55,8 @@ class AdIdentifierTests {
 
         every { mockApplication.packageName } returns "testPackage"
 
-        mockkStatic(AdvertisingIdClient::class)
-
-        every { AdvertisingIdClient.getAdvertisingIdInfo(any()) } returns adInfo
+        adidProvider = { adInfo }
+        appSetClientProvider = { appSetClient }
 
         every { adInfo.id } returns "ad_id"
         every { adInfo.isLimitAdTrackingEnabled } returns false
@@ -62,16 +64,21 @@ class AdIdentifierTests {
         val mockAdInfoIdTask = mockk<Task<AppSetIdInfo>>()
         every { mockAdInfoIdTask.isSuccessful } returns true
         every { mockAdInfoIdTask.result } returns appSetIdInfo
-        every { mockAdInfoIdTask.addOnSuccessListener{ any<AppSetIdInfo>()} } returns mockAdInfoIdTask
 
-        mockkStatic(AppSet::class)
-        every { AppSet.getClient(any()) } returns appSetClient
+        val slot = slot<com.google.android.gms.tasks.OnSuccessListener<AppSetIdInfo>>()
+        every { mockAdInfoIdTask.addOnSuccessListener(capture(slot)) } answers {
+            slot.captured.onSuccess(appSetIdInfo)
+            mockAdInfoIdTask
+        }
+
         every { appSetClient.appSetIdInfo } returns mockAdInfoIdTask
+        every { appSetIdInfo.id } returns "app_set_id"
+        every { appSetIdInfo.scope } returns 1
     }
 
     @Test
     fun fetchAdInfo_AddsToDataLayer_WhenAdInfoAvailable() {
-        AdIdentifier.create(tealiumContext) as AdIdentifier
+        AdIdentifier(tealiumContext, adidProvider, appSetClientProvider)
 
         verify(timeout = 100) {
             dataLayer.putString("google_adid", "ad_id", any())
@@ -81,8 +88,8 @@ class AdIdentifierTests {
 
     @Test
     fun fetchAdInfo_DoesNotAddToDataLayer_WhenAdInfoUnavailable() {
-        every { AdvertisingIdClient.getAdvertisingIdInfo(any()).id } returns null
-        AdIdentifier.create(tealiumContext) as AdIdentifier
+        every { adInfo.id } returns null
+        AdIdentifier(tealiumContext, adidProvider, appSetClientProvider)
 
         verify(timeout = 100) {
             dataLayer wasNot Called
@@ -91,7 +98,9 @@ class AdIdentifierTests {
 
     @Test
     fun fetchAdInfo_DoesNotAddToDataLayer_WhenGoogleApiUnavailable() {
-        AdIdentifier.create(tealiumContext) as AdIdentifier
+        AdIdentifier(tealiumContext, {
+            throw GooglePlayServicesNotAvailableException(0)
+        }, appSetClientProvider)
 
         verify(timeout = 100) {
             dataLayer wasNot Called
@@ -100,22 +109,20 @@ class AdIdentifierTests {
 
     @Test
     fun removeAdInfo_SuccessfulRemovalFromDataLayer() {
-        val adIdentifier = AdIdentifier.create(tealiumContext) as AdIdentifier
+        val adIdentifier = AdIdentifier(tealiumContext, adidProvider, appSetClientProvider)
         adIdentifier.removeAdInfo()
 
-        verify {
+        verify(timeout = 100) {
             dataLayer.remove("google_adid")
             dataLayer.remove("google_limit_ad_tracking")
         }
     }
 
-    // TODO Test currently ignored - robolectric does not support SDK 31
     @Test
-    @Config(sdk = [31])
     fun fetchAppSetIdInfo() {
-        AdIdentifier.create(tealiumContext) as AdIdentifier
+        AdIdentifier(tealiumContext, adidProvider, appSetClientProvider)
 
-        verify {
+        verify(timeout = 100) {
             dataLayer.putInt("google_app_set_scope", 1, any())
             dataLayer.putString("google_app_set_id", "app_set_id", any())
         }
@@ -123,10 +130,10 @@ class AdIdentifierTests {
 
     @Test
     fun removeAppSetIdInfo() {
-        val adIdentifier = AdIdentifier.create(tealiumContext) as AdIdentifier
+        val adIdentifier = AdIdentifier(tealiumContext, adidProvider, appSetClientProvider)
         adIdentifier.removeAppSetIdInfo()
 
-        verify {
+        verify(timeout = 100) {
             dataLayer.remove("google_app_set_id")
             dataLayer.remove("google_app_set_scope")
         }

--- a/tealiumlibrary/src/test/java/com/tealium/core/SessionManagerTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/SessionManagerTests.kt
@@ -224,11 +224,12 @@ class SessionManagerTests {
         sessionManager = SessionManager(config, eventRouter)
         val session = sessionManager.currentSession
 
+        delay(20)
+
         val otherConfig = TealiumConfig(context, "test2", "main", Environment.QA)
         val otherSessionManager = SessionManager(otherConfig, eventRouter)
         val otherSession = otherSessionManager.currentSession
 
-        delay(20)
         assertNotEquals(session.id, otherSession.id)
     }
 


### PR DESCRIPTION
 - Dependency injection rework on AdIdentifier to allow easier mocking 
 - Updated Robolectric on AdIdentifier module to test on existing test versions as well as the new target
   - 21 (min SDK version), 29 (old target), and 33 (new target)
 - Minor test fix for the core session manager too that kept failing locally.