### PR TITLE
[MT-1756] - Latest Consent gets applied before dispatching

### DIFF
--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
@@ -172,6 +172,9 @@ class ConsentManager(
      */
     override fun shouldQueue(dispatch: Dispatch?): Boolean {
         expireConsent()
+
+        dispatch?.addAll(getPolicyStatusInfo())
+
         return consentManagementPolicy?.shouldQueue()
             ?: false
     }
@@ -188,17 +191,27 @@ class ConsentManager(
      * Returns the status information from the current [ConsentPolicy] in force, else an empty map.
      */
     override suspend fun collect(): Map<String, Any> {
-        return (if (userConsentStatus != ConsentStatus.UNKNOWN && consentManagementPolicy != null) {
-            consentManagementPolicy.policyStatusInfo().mapKeys { entry ->
-                if (entry.key == Dispatch.Keys.CONSENT_CATEGORIES)
-                    consentCategoriesKey ?: Dispatch.Keys.CONSENT_CATEGORIES
-                else entry.key
-            }.toMutableMap()
-        } else mutableMapOf()).apply {
-            lastConsentUpdate?.let {
-                put(Dispatch.Keys.CONSENT_LAST_UPDATED, it)
-            }
+        return getPolicyStatusInfo()
+    }
+
+    private fun getPolicyStatusInfo(): Map<String, Any> {
+        val lastUpdated = mutableMapOf<String, Any>()
+        lastConsentUpdate?.let {
+            lastUpdated.put(Dispatch.Keys.CONSENT_LAST_UPDATED, it)
         }
+
+        if (consentManagementPolicy == null)
+            return lastUpdated
+
+        val policyStatus = lastUpdated + consentManagementPolicy.policyStatusInfo()
+        if (consentCategoriesKey == null) {
+            return policyStatus
+        }
+
+        val categories = policyStatus[Dispatch.Keys.CONSENT_CATEGORIES]
+        return if (categories != null) {
+            policyStatus - Dispatch.Keys.CONSENT_CATEGORIES + (consentCategoriesKey to categories)
+        } else policyStatus
     }
 
     override fun onLibrarySettingsUpdated(settings: LibrarySettings) {

--- a/tealiumlibrary/src/main/java/com/tealium/core/messaging/DispatchRouter.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/messaging/DispatchRouter.kt
@@ -210,6 +210,9 @@ internal class DispatchRouter(
             if (batchNo >= batches && dispatch != null) {
                 batch = batch.plus(dispatch)
             }
+            batch.forEach {
+                shouldQueue(it)
+            }
             sendDispatches(batch)
 
             batch = dispatchStore.dequeue(batchSize)

--- a/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/DispatchRouterTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/DispatchRouterTests.kt
@@ -585,6 +585,17 @@ class DispatchRouterTests {
         }
     }
 
+    @Test
+    fun testShouldQueueIsCalledAgainWithPreviouslyQueuedDispatches() {
+        dispatchRouter.batchedDequeue(eventDispatch)
+
+        verify {
+            (queuedEvents + eventDispatch).forEach {
+                validator.shouldQueue(it)
+            }
+        }
+    }
+
     private fun createDispatches(count: Int): List<Dispatch> =
         (1 .. count).map {
             TealiumEvent("event_$it")


### PR DESCRIPTION
DispatchRouter now calls `shouldQueue` again with each `Dispatch` before dispatching
ConsentManager now adds latest consent info before dispatching