### PR TITLE
[MT-1738] - DeviceCollector battery status checked on each collect call

### DIFF
--- a/tealiumlibrary/src/main/java/com/tealium/core/collection/DeviceCollector.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/collection/DeviceCollector.kt
@@ -51,8 +51,9 @@ class DeviceCollector private constructor(private val context: Context) : Collec
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
     private val point = Point()
-    private val intent = IntentFilter(Intent.ACTION_BATTERY_CHANGED)
-    private val batteryStatus = context.registerReceiver(null, intent)
+    private val batteryIntentFilter = IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+    private val batteryStatus
+        get() = context.registerReceiver(null, batteryIntentFilter)
 
     override val device = if (Build.MODEL.startsWith(Build.MANUFACTURER)) Build.MODEL
             ?: "" else "${Build.MANUFACTURER} ${Build.MODEL}"


### PR DESCRIPTION
BugFix: Rechecks Battery info on each `collect`