### PR TITLE
[MT-1690] - Consent Logging updates

### DIFF
--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/TealiumTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/TealiumTests.kt
@@ -444,16 +444,17 @@ class TealiumTests {
             .commit()
     }
 
-    private suspend fun awaitCreateTealium(
-        name: String,
-        config: TealiumConfig,
-        onReady: Tealium.() -> Unit = {}
-    ): Tealium {
-        return suspendCancellableCoroutine { cont ->
-            Tealium.create(name, config) {
-                onReady.invoke(this)
-                cont.resume(this, null)
-            }
+}
+
+suspend fun awaitCreateTealium(
+    name: String,
+    config: TealiumConfig,
+    onReady: Tealium.() -> Unit = {}
+): Tealium {
+    return suspendCancellableCoroutine { cont ->
+        Tealium.create(name, config) {
+            onReady.invoke(this)
+            cont.resume(this, null)
         }
     }
 }

--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/consent/ConsentLoggingTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/consent/ConsentLoggingTests.kt
@@ -1,0 +1,118 @@
+package com.tealium.core.consent
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.tealium.core.DispatcherFactory
+import com.tealium.core.Environment
+import com.tealium.core.Tealium
+import com.tealium.core.TealiumConfig
+import com.tealium.core.awaitCreateTealium
+import com.tealium.dispatcher.Dispatch
+import com.tealium.dispatcher.Dispatcher
+import com.tealium.dispatcher.TealiumEvent
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class ConsentLoggingTests {
+
+    @RelaxedMockK
+    lateinit var dispatcherFactory: DispatcherFactory
+
+    @RelaxedMockK
+    lateinit var dispatcher: Dispatcher
+
+    lateinit var tealium: Tealium
+    lateinit var application: Application
+
+    @Before
+    fun setUp() = runBlocking {
+        MockKAnnotations.init(this@ConsentLoggingTests)
+
+        application = ApplicationProvider.getApplicationContext()
+        every { dispatcher.name } returns "dispatcher"
+        every { dispatcher.enabled } returns true
+        every { dispatcherFactory.create(any(), any()) } returns dispatcher
+
+        val config = TealiumConfig(
+            application,
+            "test",
+            "test",
+            Environment.DEV,
+            dispatchers = mutableSetOf(dispatcherFactory)
+        ).apply {
+            consentManagerLoggingEnabled = true
+            consentManagerPolicy = ConsentPolicy.GDPR
+        }
+        tealium = awaitCreateTealium("test", config)
+    }
+
+    @Test
+    fun dispatcher_Receives_Consent_Granted_Event_When_Consent_Granted() = runTest {
+        tealium.consentManager.userConsentStatus = ConsentStatus.CONSENTED
+
+        coVerify(timeout = 1000) {
+            dispatcher.onDispatchSend(match { it[Dispatch.Keys.TEALIUM_EVENT] == ConsentManagerConstants.GRANT_FULL_CONSENT })
+        }
+    }
+
+    @Test
+    fun dispatcher_Receives_Partial_Consent_Granted_Event_When_Consent_Partially_Granted() = runTest {
+        tealium.consentManager.userConsentCategories = setOf(ConsentCategory.CDP)
+
+        coVerify(timeout = 1000) {
+            dispatcher.onDispatchSend(match { it[Dispatch.Keys.TEALIUM_EVENT] == ConsentManagerConstants.GRANT_PARTIAL_CONSENT })
+        }
+    }
+
+    @Test
+    fun dispatcher_Receives_Decline_Consent_Event_When_Consent_Declined() = runTest {
+        tealium.consentManager.userConsentStatus = ConsentStatus.NOT_CONSENTED
+
+        coVerify(timeout = 1000) {
+            dispatcher.onDispatchSend(match { it[Dispatch.Keys.TEALIUM_EVENT] == ConsentManagerConstants.DECLINE_CONSENT })
+        }
+    }
+
+    @Test
+    fun dispatcher_Receives_Other_Queued_Events_When_Consent_Granted() = runTest {
+        val queuedEvent = TealiumEvent("other_event")
+        tealium.track(queuedEvent)
+
+        tealium.consentManager.userConsentStatus = ConsentStatus.CONSENTED
+
+        coVerify(timeout = 1000) {
+            dispatcher.onDispatchSend(match { it.id == queuedEvent.id })
+        }
+    }
+
+    @Test
+    fun dispatcher_Receives_Other_Queued_Events_When_Consent_Partially_Granted() = runTest {
+        val queuedEvent = TealiumEvent("other_event")
+        tealium.track(queuedEvent)
+
+        tealium.consentManager.userConsentCategories = setOf(ConsentCategory.CDP)
+
+        coVerify(timeout = 1000) {
+            dispatcher.onDispatchSend(match { it.id == queuedEvent.id })
+        }
+    }
+
+    @Test
+    fun dispatcher_Does_Not_Receive_Other_Queued_Events_When_Consent_Declined() = runTest {
+        val queuedEvent = TealiumEvent("other_event")
+        tealium.track(queuedEvent)
+
+        tealium.consentManager.userConsentStatus = ConsentStatus.NOT_CONSENTED
+
+        coVerify(timeout = 1000, inverse = true) {
+            dispatcher.onDispatchSend(match { it.id == queuedEvent.id })
+        }
+    }
+}
+

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
@@ -162,7 +162,7 @@ class ConsentManager(
             it.userConsentPreferences = preferences
             eventRouter.onUserConsentPreferencesUpdated(preferences, it)
 
-            if (isConsentLoggingEnabled) {
+            if (isConsentLoggingEnabled && userConsentStatus != ConsentStatus.UNKNOWN) {
                 logConsentUpdate()
             }
         }

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
@@ -1,14 +1,15 @@
 package com.tealium.core.consent
 
-import com.tealium.core.*
+import com.tealium.core.Collector
+import com.tealium.core.Logger
+import com.tealium.core.TealiumContext
 import com.tealium.core.messaging.EventRouter
 import com.tealium.core.messaging.LibrarySettingsUpdatedListener
 import com.tealium.core.settings.LibrarySettings
 import com.tealium.core.validation.DispatchValidator
+import com.tealium.dispatcher.AuditEvent
 import com.tealium.dispatcher.Dispatch
-import com.tealium.dispatcher.TealiumEvent
 import com.tealium.tealiumlibrary.BuildConfig
-import java.lang.Exception
 import java.util.concurrent.TimeUnit
 
 class ConsentManager(
@@ -94,7 +95,7 @@ class ConsentManager(
             if (policy.consentLoggingEnabled) {
                 // profile override checked in dispatchers, url override checked in Collect dispatcher
                 context.track(
-                    TealiumEvent(
+                    AuditEvent(
                         policy.consentLoggingEventName,
                         policy.policyStatusInfo()
                     )

--- a/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/consent/ConsentManager.kt
@@ -210,8 +210,11 @@ class ConsentManager(
         const val MODULE_VERSION = BuildConfig.LIBRARY_VERSION
 
         fun isConsentGrantedEvent(dispatch: Dispatch): Boolean {
-            return (ConsentManagerConstants.GRANT_FULL_CONSENT == dispatch[Dispatch.Keys.TEALIUM_EVENT]
-                    || ConsentManagerConstants.GRANT_PARTIAL_CONSENT == dispatch[Dispatch.Keys.TEALIUM_EVENT])
+            val tealiumEvent = dispatch[Dispatch.Keys.TEALIUM_EVENT] ?: return false
+
+            return (ConsentManagerConstants.GRANT_FULL_CONSENT == tealiumEvent
+                    || ConsentManagerConstants.GRANT_PARTIAL_CONSENT == tealiumEvent
+                    || ConsentManagerConstants.DECLINE_CONSENT == tealiumEvent)
         }
     }
 }

--- a/tealiumlibrary/src/main/java/com/tealium/core/persistence/DispatchStorage.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/persistence/DispatchStorage.kt
@@ -121,6 +121,7 @@ internal class DispatchStorage(
     override fun count(): Int = dao.count()
     override fun contains(key: String): Boolean = dao.contains(key)
     override fun purgeExpired() = dao.purgeExpired()
+    override fun clearNonAuditEvents() = dao.clearNonAuditEvents()
 
     private fun convertToDispatch(json: PersistentItem): Dispatch {
         return JsonDispatch(json)

--- a/tealiumlibrary/src/main/java/com/tealium/core/persistence/DispatchStorageDao.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/persistence/DispatchStorageDao.kt
@@ -5,6 +5,7 @@ import com.tealium.core.persistence.SqlDataLayer.Columns.COLUMN_EXPIRY
 import com.tealium.core.persistence.SqlDataLayer.Columns.COLUMN_KEY
 import com.tealium.core.persistence.SqlDataLayer.Columns.COLUMN_TIMESTAMP
 import com.tealium.core.persistence.SqlDataLayer.Columns.COLUMN_VALUE
+import com.tealium.dispatcher.AuditEvent
 import java.util.concurrent.TimeUnit
 
 /**
@@ -176,6 +177,16 @@ internal class DispatchStorageDao(
     override fun resize(size: Int) {
         maxQueueSize = size
         createSpaceIfRequired(0)
+    }
+
+    override fun clearNonAuditEvents() {
+        val storage = db ?: return
+
+        storage.delete(
+            tableName,
+            "$COLUMN_KEY NOT LIKE ?",
+            arrayOf("${AuditEvent.AUDIT_ID_PREFIX}%")
+        )
     }
 
     /**

--- a/tealiumlibrary/src/main/java/com/tealium/core/persistence/QueueingDao.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/persistence/QueueingDao.kt
@@ -27,4 +27,9 @@ interface QueueingDao<K, T> : KeyValueDao<K, T> {
      * Should resize the queue, removing entries from the queue if necessary.
      */
     fun resize(size: Int)
+
+    /**
+     * Removes all events excluding those deemed to be "audit" events
+     */
+    fun clearNonAuditEvents()
 }

--- a/tealiumlibrary/src/main/java/com/tealium/dispatcher/AuditEvent.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/dispatcher/AuditEvent.kt
@@ -1,0 +1,33 @@
+package com.tealium.dispatcher
+
+class AuditEvent(
+    val eventName: String,
+    data: Map<String, Any>? = null
+) : Dispatch {
+
+    private val delegate: Dispatch = TealiumEvent(eventName, data)
+
+    override val id: String =
+        "$AUDIT_ID_PREFIX${delegate.id}"
+
+    override var timestamp: Long? = delegate.timestamp
+
+    override fun payload(): Map<String, Any> =
+        delegate.payload()
+
+    override fun addAll(data: Map<String, Any>) =
+        delegate.addAll(data)
+
+    override fun remove(key: String) =
+        delegate.remove(key)
+
+    companion object {
+        const val AUDIT_ID_PREFIX = "audit-"
+
+        fun isAuditEvent(dispatch: Dispatch): Boolean =
+            dispatch is AuditEvent || isAuditEvent(dispatch.id)
+
+        fun isAuditEvent(id: String): Boolean =
+            id.startsWith(AUDIT_ID_PREFIX)
+    }
+}

--- a/tealiumlibrary/src/test/java/com/tealium/core/consent/ConsentManagerTest.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/consent/ConsentManagerTest.kt
@@ -15,11 +15,13 @@ import com.tealium.core.network.ConnectivityRetriever
 import com.tealium.core.network.HttpClient
 import com.tealium.core.settings.LibrarySettings
 import com.tealium.dispatcher.Dispatch
+import com.tealium.dispatcher.JsonDispatch
 import com.tealium.dispatcher.TealiumEvent
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -166,12 +168,19 @@ class ConsentManagerTest {
     @Test
     fun setUserConsentStatusConsentedSetsAllCategories() {
         every { editor.putString(KEY_STATUS, "consented") } returns editor
-        every { editor.putStringSet(
-            KEY_CATEGORIES,
-            ConsentCategory.ALL.map { it.value }.toMutableSet()
-        ) } returns editor
+        every {
+            editor.putStringSet(
+                KEY_CATEGORIES,
+                ConsentCategory.ALL.map { it.value }.toMutableSet()
+            )
+        } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
-        every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns ConsentCategory.ALL.map { it.value }.toMutableSet()
+        every {
+            sharedPreferences.getStringSet(
+                KEY_CATEGORIES,
+                null
+            )
+        } returns ConsentCategory.ALL.map { it.value }.toMutableSet()
         consentManager.userConsentStatus = ConsentStatus.CONSENTED
         assertEquals(ConsentStatus.CONSENTED, consentManager.userConsentStatus)
         assertEquals(15, consentManager.userConsentCategories?.count())
@@ -192,7 +201,8 @@ class ConsentManagerTest {
         every { sharedPreferences.getString(any(), any()) } returns "consented"
         every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns setOf("crm")
         every { editor.putStringSet(KEY_CATEGORIES, setOf("engagement")) } returns editor
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
         consentManager.userConsentCategories = setOf(ConsentCategory.ENGAGEMENT)
 
         // no policy == no updates.
@@ -207,7 +217,8 @@ class ConsentManagerTest {
         every { sharedPreferences.getString(any(), any()) } returns "consented"
         every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns setOf("engagement")
         every { editor.putStringSet(KEY_CATEGORIES, setOf("engagement")) } returns editor
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
         consentManager.userConsentCategories = setOf(ConsentCategory.ENGAGEMENT)
 
         // no policy == no updates.
@@ -248,7 +259,8 @@ class ConsentManagerTest {
         every { sharedPreferences.getString(any(), any()) } returns "consented"
         every { sharedPreferences.getStringSet(KEY_CATEGORIES, null) } returns setOf("affiliates")
         every { editor.putStringSet(KEY_CATEGORIES, setOf("affiliates")) } returns editor
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentCategories = setOf(ConsentCategory.AFFILIATES)
 
         assertEquals(ConsentStatus.CONSENTED, consentManager.userConsentStatus)
@@ -272,9 +284,10 @@ class ConsentManagerTest {
         mockkObject(ConnectivityRetriever)
         every { ConnectivityRetriever.getInstance(any<Application>()) } returns mockConnectivity
 
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentStatus = ConsentStatus.UNKNOWN
-        verify(exactly = 0){
+        verify(exactly = 0) {
             mockTealiumContext.track(any())
         }
     }
@@ -292,7 +305,8 @@ class ConsentManagerTest {
         mockkObject(ConnectivityRetriever)
         every { ConnectivityRetriever.getInstance(any<Application>()) } returns mockConnectivity
 
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentStatus = ConsentStatus.UNKNOWN
         verify(exactly = 0) {
             mockTealiumContext.track(any())
@@ -313,7 +327,8 @@ class ConsentManagerTest {
         mockkObject(ConnectivityRetriever)
         every { ConnectivityRetriever.getInstance(any<Application>()) } returns mockConnectivity
 
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentStatus = ConsentStatus.CONSENTED
 
         verify {
@@ -336,7 +351,8 @@ class ConsentManagerTest {
         mockkObject(ConnectivityRetriever)
         every { ConnectivityRetriever.getInstance(any<Application>()) } returns mockConnectivity
 
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentStatus = ConsentStatus.CONSENTED
 
         verify {
@@ -352,7 +368,8 @@ class ConsentManagerTest {
         every { editor.putString(KEY_STATUS, "consented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
 
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentStatus = ConsentStatus.CONSENTED
 
         val payload = consentManager.collect()
@@ -367,7 +384,8 @@ class ConsentManagerTest {
         every { editor.putString(KEY_STATUS, "consented") } returns editor
         every { sharedPreferences.getString(any(), any()) } returns "consented"
 
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockSettings, ConsentPolicy.GDPR)
         consentManager.userConsentStatus = ConsentStatus.CONSENTED
 
         val payload = consentManager.collect()
@@ -506,7 +524,8 @@ class ConsentManagerTest {
         every { editor.putLong(KEY_LAST_STATUS_UPDATE, mockTime) } returns editor
         every { sharedPreferences.getLong(any(), any()) } returns mockTime
         every { sharedPreferences.getString(KEY_STATUS, any()) } returns "consented"
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
 
         verify(exactly = 1) {
             eventRouter.onUserConsentPreferencesUpdated(any(), any())
@@ -517,7 +536,8 @@ class ConsentManagerTest {
     fun expireConsentDoesntCallListener() {
         every { editor.putLong(KEY_LAST_STATUS_UPDATE, 0) } returns editor
         every { sharedPreferences.getLong(any(), any()) } returns 0
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.GDPR)
 
         verify(exactly = 0) {
             eventRouter.onUserConsentPreferencesUpdated(any(), any())
@@ -528,7 +548,8 @@ class ConsentManagerTest {
     fun consentManager_DelegatesToCustomConsentPolicy() = runBlocking {
         ConsentPolicy.CUSTOM.setCustomPolicy(mockPolicy)
         every { sharedPreferences.getString(KEY_STATUS, any()) } returns "consented"
-        consentManager = ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.CUSTOM)
+        consentManager =
+            ConsentManager(mockTealiumContext, eventRouter, mockk(), ConsentPolicy.CUSTOM)
 
         every { mockPolicy.shouldQueue() } returns true
         every { mockPolicy.shouldDrop() } returns true
@@ -538,5 +559,29 @@ class ConsentManagerTest {
         assertTrue(consentManager.shouldDrop(mockk()))
         val policyInfo = consentManager.collect()
         assertTrue(policyInfo["my_policy_name"] == "policy")
+    }
+
+    @Test
+    fun isConsentGrantedEvent_Returns_True_When_Tealium_Event_Is_One_Of_Consent_Logging_Names() {
+        listOf(
+            ConsentManagerConstants.GRANT_FULL_CONSENT,
+            ConsentManagerConstants.GRANT_PARTIAL_CONSENT,
+            ConsentManagerConstants.DECLINE_CONSENT
+        ).forEach { consentEventName ->
+            assertTrue(ConsentManager.isConsentGrantedEvent(TealiumEvent(consentEventName)))
+        }
+    }
+
+    @Test
+    fun isConsentGrantedEvent_Returns_False_When_Tealium_Event_Key_Missing() {
+        val dispatch = TealiumEvent("test")
+        dispatch.remove(Dispatch.Keys.TEALIUM_EVENT)
+        assertFalse(ConsentManager.isConsentGrantedEvent(dispatch))
+    }
+
+    @Test
+    fun isConsentGrantedEvent_Returns_False_When_Tealium_Event_Key_Not_A_Consent_Event() {
+        val dispatch = TealiumEvent("test")
+        assertFalse(ConsentManager.isConsentGrantedEvent(dispatch))
     }
 }

--- a/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/DispatchRouterTests.kt
+++ b/tealiumlibrary/src/test/java/com/tealium/core/dispatcher/DispatchRouterTests.kt
@@ -4,7 +4,10 @@ import android.util.Log
 import com.tealium.core.Collector
 import com.tealium.core.Logger
 import com.tealium.core.Transformer
+import com.tealium.core.consent.ConsentManagementPolicy
 import com.tealium.core.consent.ConsentManager
+import com.tealium.core.consent.ConsentStatus
+import com.tealium.core.consent.UserConsentPreferences
 import com.tealium.core.messaging.DispatchRouter
 import com.tealium.core.messaging.EventDispatcher
 import com.tealium.core.messaging.EventRouter
@@ -16,6 +19,7 @@ import com.tealium.core.validation.BatchingValidator
 import com.tealium.core.validation.BatteryValidator
 import com.tealium.core.validation.ConnectivityValidator
 import com.tealium.core.validation.DispatchValidator
+import com.tealium.dispatcher.AuditEvent
 import com.tealium.dispatcher.Dispatch
 import com.tealium.dispatcher.Dispatcher
 import com.tealium.dispatcher.TealiumEvent
@@ -28,6 +32,7 @@ import io.mockk.excludeRecords
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
@@ -258,6 +263,20 @@ class DispatchRouterTests {
         verify(exactly = 0) {
             // no further routing should happen
             validator.shouldQueue(eventDispatch)
+        }
+    }
+
+    @Test
+    fun testIsNotDroppedWhenAuditEvent() {
+        every { validator.name } returns "mock_validator"
+        every { validator.shouldDrop(eventDispatch) } returns true
+        val auditEvent = AuditEvent("some_audit_event")
+
+        dispatchRouter.track(auditEvent)
+
+        verify(exactly = 1) {
+            // no further routing should happen
+            validator.shouldQueue(auditEvent)
         }
     }
 
@@ -496,6 +515,17 @@ class DispatchRouterTests {
     }
 
     @Test
+    fun trackProcessesForRemoteCommandsWhenQueuedButIsAuditEvent() = runBlocking {
+        every { validator.shouldQueue(any()) } returns true
+        val auditEvent = AuditEvent("some_audit_event")
+        dispatchRouter.track(auditEvent)
+
+        verify(timeout = 1000) {
+            eventRouter.onProcessRemoteCommand(auditEvent)
+        }
+    }
+
+    @Test
     fun trackDoesNotProcessForRemoteCommandsWhenQueued() = runBlocking {
         every { validator.shouldQueue(any()) } returns true
         dispatchRouter.track(eventDispatch)
@@ -585,8 +615,40 @@ class DispatchRouterTests {
         }
     }
 
+    @Test
+    fun onUserConsentPreferencesUpdatedClearsNonAuditEventsWhenPolicyShouldDrop() {
+        val policy = mockk<ConsentManagementPolicy>(relaxed = true)
+        every { policy.shouldDrop() } returns true
+        every { policy.shouldQueue() } returns true
+
+        dispatchRouter.onUserConsentPreferencesUpdated(
+            UserConsentPreferences(ConsentStatus.CONSENTED),
+            policy
+        )
+
+        verify {
+            dispatchStore.clearNonAuditEvents()
+        }
+    }
+
+    @Test
+    fun onUserConsentPreferencesUpdatedRevalidatesWhenThereAreQueuedEventsAndPolicyShouldNotQueue() {
+        val policy = mockk<ConsentManagementPolicy>(relaxed = true)
+        every { policy.shouldDrop() } returns false
+        every { policy.shouldQueue() } returns false
+
+        dispatchRouter.onUserConsentPreferencesUpdated(
+            UserConsentPreferences(ConsentStatus.CONSENTED),
+            policy
+        )
+
+        verify {
+            dispatchStore.dequeue(any())
+        }
+    }
+
     private fun createDispatches(count: Int): List<Dispatch> =
-        (1 .. count).map {
+        (1..count).map {
             TealiumEvent("event_$it")
         }
 
@@ -595,7 +657,8 @@ class DispatchRouterTests {
      *
      * Only methods relevant to testing are properly implemented
      */
-    private class VolatileDispatchStore(initialList: List<Dispatch> = emptyList()) : QueueingDao<String, Dispatch> {
+    private class VolatileDispatchStore(initialList: List<Dispatch> = emptyList()) :
+        QueueingDao<String, Dispatch> {
         private val queue: Queue<Dispatch> = LinkedList(initialList)
 
         override fun enqueue(item: Dispatch) {
@@ -658,6 +721,10 @@ class DispatchRouterTests {
 
         override fun purgeExpired() {
             // no-op
+        }
+
+        override fun clearNonAuditEvents() {
+            queue.removeIf { !AuditEvent.isAuditEvent(it) }
         }
     }
 }


### PR DESCRIPTION
Introduces non-public `AuditEvent` as a `Dispatch` implementation used by Consent Management for consent logging.

AuditEvents are not droppable by either DispatchValidators, or the existing purge triggered by declining consent, and are therefore persistent regardless of consent status. They are still queue-able to ensure they can be safely dispatched.