### PR TITLE
[MT-1937] - Moments API 1.0.6

### DIFF
--- a/momentsapi/build.gradle
+++ b/momentsapi/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
 }
 
-version = '1.0.5'
+version = '1.0.6'
 
 android {
     namespace = 'com.tealium.momentsapi'

--- a/momentsapi/src/main/java/com/tealium/momentsapi/MomentsApiService.kt
+++ b/momentsapi/src/main/java/com/tealium/momentsapi/MomentsApiService.kt
@@ -44,7 +44,7 @@ class MomentsApiService @JvmOverloads constructor(
     override val name: String = MODULE_NAME
 
     private val engineUrl: String =
-        "https://personalization-api.${region.value}.prod.tealiumapis.com/personalization/accounts/${context.config.accountName}/profiles/${context.config.profileName}/"
+        "https://personalization-api.${region.value}.prod.tealiumapis.com/personalization/accounts/${context.config.accountName}/profiles/${context.config.profileName}"
 
     private val referrer = context.config.momentsApiReferrer
         ?: "https://tags.tiqcdn.com/utag/${context.config.accountName}/${context.config.profileName}/${context.config.environment.environment}/mobile.html"

--- a/momentsapi/src/main/java/com/tealium/momentsapi/network/HttpClient.kt
+++ b/momentsapi/src/main/java/com/tealium/momentsapi/network/HttpClient.kt
@@ -20,6 +20,7 @@ class HttpClient(
     override fun get(url: URL, referrer: String, listener: ResponseListener<String>) {
         if (!connectivityRetriever.isConnected()) {
             listener.failure(ErrorCode.NOT_CONNECTED, ErrorCode.NOT_CONNECTED.message)
+            return
         }
 
         with(url.openConnection() as HttpURLConnection) {

--- a/momentsapi/src/test/java/com/tealium/momentsapi/MomentsApiServiceTest.kt
+++ b/momentsapi/src/test/java/com/tealium/momentsapi/MomentsApiServiceTest.kt
@@ -108,7 +108,7 @@ class MomentsApiServiceTest {
     }
 
     @Test
-    fun fetchEngineResponse_Builds_Valid_URL() {
+    fun fetchEngineResponseBuildsValidUrl() {
         coEvery { networkClient.get(any(), any(), any<ResponseListener<String>>()) } just Runs
 
         apiService.fetchEngineResponse("test-engine", listener)

--- a/momentsapi/src/test/java/com/tealium/momentsapi/MomentsApiServiceTest.kt
+++ b/momentsapi/src/test/java/com/tealium/momentsapi/MomentsApiServiceTest.kt
@@ -6,9 +6,12 @@ import com.tealium.core.TealiumConfig
 import com.tealium.core.TealiumContext
 import com.tealium.momentsapi.network.NetworkClient
 import io.mockk.MockKAnnotations
+import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
@@ -61,7 +64,6 @@ class MomentsApiServiceTest {
 
         coEvery { networkClient.get(any(), any(), any<ResponseListener<String>>()) } answers {
             thirdArg<ResponseListener<String>>().success("{ \"audiences\": {\"audience_1\": \"VIP\", \"audience_2\": \"Women's Apparel\", \"audience_2\": \"Lifetime visit count\"} }")
-            thirdArg<ResponseListener<String>>().failure(ErrorCode.INVALID_JSON, ErrorCode.INVALID_JSON.message)
         }
 
         apiService.fetchEngineResponse(engineId, listener)
@@ -102,6 +104,19 @@ class MomentsApiServiceTest {
                 ErrorCode.INVALID_JSON,
                 ErrorCode.INVALID_JSON.message
             )
+        }
+    }
+
+    @Test
+    fun fetchEngineResponse_Builds_Valid_URL() {
+        coEvery { networkClient.get(any(), any(), any<ResponseListener<String>>()) } just Runs
+
+        apiService.fetchEngineResponse("test-engine", listener)
+
+        coVerify(timeout = 1000) {
+            networkClient.get(match {
+                it.toString() == "https://personalization-api.us-east-1.prod.tealiumapis.com/personalization/accounts/test/profiles/test/engines/test-engine/visitors/abc123?ignoreTapid=true"
+            }, any(), any())
         }
     }
 }


### PR DESCRIPTION
 - Bugfix: removes a duplicate forward slash from the personalization API URL
 - Bugfix: doesn't make the HTTP request when connectivity is known to be unavailable