### PR TITLE
[MT-2015] - Fix: move migration timing to before VisitorIdProvider instantiation

### DIFF
--- a/tealiumlibrary/src/androidTest/java/com/tealium/core/MigrationTests.kt
+++ b/tealiumlibrary/src/androidTest/java/com/tealium/core/MigrationTests.kt
@@ -7,12 +7,18 @@ import com.tealium.core.consent.ConsentCategory
 import com.tealium.core.consent.ConsentManagerConstants.KEY_CATEGORIES
 import com.tealium.core.consent.ConsentManagerConstants.KEY_STATUS
 import com.tealium.core.consent.ConsentStatus
+import com.tealium.dispatcher.Dispatch
 import io.mockk.MockKAnnotations
+import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.util.*
+import java.util.Arrays
 
 class MigrationTests {
 
@@ -143,6 +149,38 @@ class MigrationTests {
         assertTrue(tealium.dataLayer.getBoolean("my_boolean_true")!!)
         assertFalse(tealium.dataLayer.getBoolean("my_boolean_false")!!)
         assertTrue(Arrays.equals(arrayOf("string_value_1", "string_value_2"), tealium.dataLayer.getStringArray("my_string_set")!!.sortedArray()))
+    }
+
+    @Test
+    fun visitorId_GetsMigrated_FromSharedPreferences() {
+        val migratedVisitorId = "visitor_1"
+        dataSourcesPreferences.edit()
+            .putString(Dispatch.Keys.TEALIUM_VISITOR_ID, migratedVisitorId)
+            .commit()
+
+        tealium = Tealium.create("instance_name", config)
+        assertEquals(
+            tealium.dataLayer.getString(Dispatch.Keys.TEALIUM_VISITOR_ID),
+            tealium.visitorId
+        )
+        assertEquals(
+            migratedVisitorId,
+            tealium.dataLayer.getString(Dispatch.Keys.TEALIUM_VISITOR_ID)
+        )
+        assertEquals(migratedVisitorId, tealium.visitorId)
+    }
+
+    @Test
+    fun visitorId_FromProvider_Is_Collected_After_Migration() = runBlocking {
+        val migratedVisitorId = "visitor_1"
+        dataSourcesPreferences.edit()
+            .putString(Dispatch.Keys.TEALIUM_VISITOR_ID, migratedVisitorId)
+            .commit()
+
+        tealium = awaitCreateTealium("instance_name", config)
+        val secureVisitorId = tealium.visitorId
+        val trackData = tealium.gatherTrackData()
+        assertEquals(secureVisitorId, trackData[Dispatch.Keys.TEALIUM_VISITOR_ID])
     }
 
     fun getHashCodeString(config: TealiumConfig, delimiter: String = ""): String {

--- a/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
+++ b/tealiumlibrary/src/main/java/com/tealium/core/Tealium.kt
@@ -142,6 +142,12 @@ class Tealium private constructor(
     val dataLayer: DataLayer
         get() = _dataLayer
 
+    init {
+        // requires DataLayer to be available, but must happen before VisitorIdProvider
+        // in order to correctly migrate the VisitorId
+        migratePersistentData()
+    }
+
     /**
      * Object representing the current Tealium session in progress.
      */
@@ -188,7 +194,6 @@ class Tealium private constructor(
         ConsentManager(context, eventRouter, librarySettingsManager.librarySettings)
 
     init {
-        migratePersistentData()
         if (sessionManager.isNewSessionOnLaunch) {
             _dataLayer.clearSessionData(session.id)
         }


### PR DESCRIPTION
Why
 - automatic migrations from `tealium-android` library to `tealium-kotlin` versions `1.5.0 <= 1.9.2` would migrate the previous `tealium_visitor_id` into the DataLayer, but generate a new visitor id for the `Tealium.visitorId` property
 - the existing visitor id would continue to receive events tracked

What
 - fix the timing of the migration, such that existing visitor id are correctly migrated to both the datalayer and `visitorId` property